### PR TITLE
Color Fix + Basic Testing Framework

### DIFF
--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -225,6 +225,10 @@ default-multi-sort-method = method(self,
   self.constr()(self.obj.{tab: sorted-table})
 end
 
+axis-format-method = method(self, format-string :: String): 
+  self.constr()(self.obj.{format: format-string})
+end
+
 ################################################################################
 # BOUNDING BOX
 ################################################################################
@@ -304,23 +308,27 @@ type BarChartSeries = {
   tab :: TableIntern,
   color :: Option<I.Color>,
   colors :: Option<List<I.Color>>,
+  format :: String
 }
 
 default-bar-chart-series = {
   color: none,
   colors: none,
+  format : ''
 }
 
 type MultiBarChartSeries = { 
   tab :: TableIntern,
   legends :: RawArray<String>,
   is-stacked :: Boolean,
-  colors :: Option<List<I.Color>>
+  colors :: Option<List<I.Color>>, 
+  format :: String
 }
 
 default-multi-bar-chart-series = {
   is-stacked: false,
-  colors: some([list: C.red, C.blue, C.green, C.orange, C.purple, C.black, C.brown])
+  colors: some([list: C.red, C.blue, C.green, C.orange, C.purple, C.black, C.brown]), 
+  format : ''
 }
   
 type HistogramSeries = {
@@ -506,6 +514,7 @@ data DataSeries:
     colors: color-list-method,
     sort-by: sort-method,
     sort-by-label: label-sort-method,
+    axis-format: axis-format-method,
     constr: {(): bar-chart-series},
   | multi-bar-chart-series(obj :: MultiBarChartSeries) with: 
     is-single: true,
@@ -513,6 +522,7 @@ data DataSeries:
     sort-by: default-multi-sort-method,
     sort-by-data: multi-sort-method, 
     sort-by-label: label-sort-method,
+    axis-format: axis-format-method,
     constr: {(): multi-bar-chart-series}
   | box-plot-series(obj :: BoxChartSeries) with:
     is-single: true,

--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -21,6 +21,7 @@ import either as E
 import string-dict as SD
 import valueskeleton as VS
 import statistics as ST
+import color as C
 
 ################################################################################
 # CONSTANTS
@@ -224,7 +225,7 @@ type MultiBarChartSeries = {
 
 default-multi-bar-chart-series = {
   is-stacked: false,
-  colors: none
+  colors: [list: C.red, C.blue, C.green, C.orange, C.purple, C.black, C.brown]
 }
   
 type HistogramSeries = {

--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -206,11 +206,13 @@ default-pie-chart-series = {}
 
 type BarChartSeries = {
   tab :: TableIntern,
-  colors :: Option<List<I.Color>>
+  color :: Option<I.Color>,
+  colors :: Option<List<I.Color>>,
 }
 
 default-bar-chart-series = {
-  colors: none
+  color: none,
+  colors: none,
 }
 
 type MultiBarChartSeries = { 

--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -225,10 +225,6 @@ default-multi-sort-method = method(self,
   self.constr()(self.obj.{tab: sorted-table})
 end
 
-axis-format-method = method(self, format-string :: String): 
-  self.constr()(self.obj.{format: format-string})
-end
-
 ################################################################################
 # BOUNDING BOX
 ################################################################################
@@ -308,27 +304,23 @@ type BarChartSeries = {
   tab :: TableIntern,
   color :: Option<I.Color>,
   colors :: Option<List<I.Color>>,
-  format :: String
 }
 
 default-bar-chart-series = {
   color: none,
   colors: none,
-  format : ''
 }
 
 type MultiBarChartSeries = { 
   tab :: TableIntern,
   legends :: RawArray<String>,
   is-stacked :: Boolean,
-  colors :: Option<List<I.Color>>, 
-  format :: String
+  colors :: Option<List<I.Color>>
 }
 
 default-multi-bar-chart-series = {
   is-stacked: false,
-  colors: some([list: C.red, C.blue, C.green, C.orange, C.purple, C.black, C.brown]), 
-  format : ''
+  colors: some([list: C.red, C.blue, C.green, C.orange, C.purple, C.black, C.brown])
 }
   
 type HistogramSeries = {
@@ -514,7 +506,6 @@ data DataSeries:
     colors: color-list-method,
     sort-by: sort-method,
     sort-by-label: label-sort-method,
-    axis-format: axis-format-method,
     constr: {(): bar-chart-series},
   | multi-bar-chart-series(obj :: MultiBarChartSeries) with: 
     is-single: true,
@@ -522,7 +513,6 @@ data DataSeries:
     sort-by: default-multi-sort-method,
     sort-by-data: multi-sort-method, 
     sort-by-label: label-sort-method,
-    axis-format: axis-format-method,
     constr: {(): multi-bar-chart-series}
   | box-plot-series(obj :: BoxChartSeries) with:
     is-single: true,

--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -741,6 +741,9 @@ fun bar-chart-from-list(labels :: List<String>, values :: List<Number>) -> DataS
   value-length = values.length()
 
   # Edge Case Error Checking
+  when value-length == 0:
+    raise("bar-chart: can't have empty data")
+  end
   when label-length <> value-length:
     raise('bar-chart: labels and values should have the same length')
   end
@@ -769,7 +772,7 @@ fun grouped-bar-chart-from-list(
   legend-length = legends.length() 
 
   # Edge Case Error Checking 
-  when label-length == 0:
+  when value-length == 0:
     raise("grouped-bar-chart: can't have empty data")
   end
   when legend-length == 0: 
@@ -809,7 +812,7 @@ fun stacked-bar-chart-from-list(
   legend-length = legends.length() 
 
   # Edge Case Error Checking 
-  when label-length == 0:
+  when value-length == 0:
     raise("stacked-bar-chart: can't have empty data")
   end
   when legend-length == 0: 

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -325,6 +325,9 @@
       options: {
         legend: {
           position: 'none'
+        }, 
+        vAxis: {
+          format: get(rawData, 'format')
         }
       },
       chartType: google.visualization.ColumnChart,
@@ -362,7 +365,10 @@
         series: colors_list.map(c => ({color: c})),
         legend: {
           position: 'right'
-        }
+        }, 
+        vAxis: {
+          format: get(rawData, 'format')
+        },
       },
       chartType: google.visualization.ColumnChart,
       onExit: defaultImageReturn,
@@ -514,7 +520,7 @@
       none: function () {},
       some: function (binWidth) {
         // NOTE(joe, aug 2019): The chart library has a bug for histograms with
-        // a single unique value (https://jsfiddle.net/L0y64fbo/2/), so thisi
+        // a single unique value (https://jsfiddle.net/L0y64fbo/2/), so this
         // hackaround makes it so this case can't come up.
         if(hasAtLeastTwoValues) {
           options.histogram.bucketSize = toFixnum(binWidth);

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -325,9 +325,6 @@
       options: {
         legend: {
           position: 'none'
-        }, 
-        vAxis: {
-          format: get(rawData, 'format')
         }
       },
       chartType: google.visualization.ColumnChart,
@@ -365,10 +362,7 @@
         series: colors_list.map(c => ({color: c})),
         legend: {
           position: 'right'
-        }, 
-        vAxis: {
-          format: get(rawData, 'format')
-        },
+        }
       },
       chartType: google.visualization.ColumnChart,
       onExit: defaultImageReturn,
@@ -520,7 +514,7 @@
       none: function () {},
       some: function (binWidth) {
         // NOTE(joe, aug 2019): The chart library has a bug for histograms with
-        // a single unique value (https://jsfiddle.net/L0y64fbo/2/), so this
+        // a single unique value (https://jsfiddle.net/L0y64fbo/2/), so thisi
         // hackaround makes it so this case can't come up.
         if(hasAtLeastTwoValues) {
           options.histogram.bucketSize = toFixnum(binWidth);

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -378,8 +378,3 @@ check "Sorting Methods: Stacked Bars":
     stacked-bars-rep.sort-by-data(weekend-weekday-scoring, ascending-cmp, vanilla-eq)) 
   satisfies is-image
 end
-
-########################
-# AXIS FORMATTER TESTS 
-########################
-

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -1,0 +1,64 @@
+include color
+include chart
+include image
+
+fun render-image(series):
+  render-chart(series).get-image()
+end
+
+single-bars = from-list.bar-chart(
+  [list: "Pyret", "OCaml", "C", "C++", "Python", "Racket", "Smalltalk"],
+  [list: 10,       6,       1,   3,     5,       8,        9])
+grouped-bars = from-list.grouped-bar-chart(
+  [list: 'CA', 'TX', 'NY', 'FL', 'IL', 'PA'],
+  [list:
+    [list: 2704659,4499890,2159981,3853788,10604510,8819342,4114496],
+    [list: 2027307,3277946,1420518,2454721,7017731,5656528,2472223],
+    [list: 1208495,2141490,1058031,1999120,5355235,5120254,2607672],
+    [list: 1140516,1938695,925060,1607297,4782119,4746856,3187797],
+    [list: 894368,1558919,725973,1311479,3596343,3239173,1575308],
+    [list: 737462,1345341,679201,1203944,3157759,3414001,1910571]],
+  [list:
+    'Under 5 Years',
+    '5 to 13 Years',
+    '14 to 17 Years',
+    '18 to 24 Years',
+    '25 to 44 Years',
+    '45 to 64 Years',
+    '65 Years and Over'])
+stacked-bars = from-list.stacked-bar-chart(
+  [list: 'CA', 'TX', 'NY', 'FL', 'IL', 'PA'],
+  [list:
+    [list: 2704659,4499890,2159981,3853788,10604510,8819342,4114496],
+    [list: 2027307,3277946,1420518,2454721,7017731,5656528,2472223],
+    [list: 1208495,2141490,1058031,1999120,5355235,5120254,2607672],
+    [list: 1140516,1938695,925060,1607297,4782119,4746856,3187797],
+    [list: 894368,1558919,725973,1311479,3596343,3239173,1575308],
+    [list: 737462,1345341,679201,1203944,3157759,3414001,1910571]],
+  [list:
+    'Under 5 Years',
+    '5 to 13 Years',
+    '14 to 17 Years',
+    '18 to 24 Years',
+    '25 to 44 Years',
+    '45 to 64 Years',
+    '65 Years and Over'])
+
+check "rendering":
+  render-image(single-bars) satisfies is-image
+  render-image(grouped-bars) satisfies is-image
+  render-image(stacked-bars) satisfies is-image
+end
+
+check "colors":
+  single-color = [list: red]
+  rainbow-colors = [list:
+    red, orange, yellow, green, blue, indigo, violet]
+
+  render-image(single-bars.default-color(red)) satisfies is-image
+  render-image(single-bars.colors(single-color)) satisfies is-image
+  render-image(single-bars.colors(rainbow-colors)) satisfies is-image
+
+  render-image(grouped-bars.colors(single-color)) satisfies is-image
+  render-image(grouped-bars.colors(rainbow-colors)) satisfies is-image
+end

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -2,13 +2,14 @@ include color
 include chart
 include image
 
-fun render-image(series):
-  render-chart(series).get-image()
-end
+################################################################################
+# CONSTANTS
+################################################################################
 
 single-bars = from-list.bar-chart(
   [list: "Pyret", "OCaml", "C", "C++", "Python", "Racket", "Smalltalk"],
   [list: 10,       6,       1,   3,     5,       8,        9])
+
 grouped-bars = from-list.grouped-bar-chart(
   [list: 'CA', 'TX', 'NY', 'FL', 'IL', 'PA'],
   [list:
@@ -26,6 +27,7 @@ grouped-bars = from-list.grouped-bar-chart(
     '25 to 44 Years',
     '45 to 64 Years',
     '65 Years and Over'])
+
 stacked-bars = from-list.stacked-bar-chart(
   [list: 'CA', 'TX', 'NY', 'FL', 'IL', 'PA'],
   [list:
@@ -44,16 +46,27 @@ stacked-bars = from-list.stacked-bar-chart(
     '45 to 64 Years',
     '65 Years and Over'])
 
-check "rendering":
+################################################################################
+# Helper Functions -- Testing 
+################################################################################
+
+fun render-image(series):
+  render-chart(series).get-image()
+end
+
+################################################################################
+# Actual Testing -- Check
+################################################################################
+
+check "Rendering":
   render-image(single-bars) satisfies is-image
   render-image(grouped-bars) satisfies is-image
   render-image(stacked-bars) satisfies is-image
 end
 
-check "colors":
+check "Color Methods: Doesn't Break Rendering":
   single-color = [list: red]
-  rainbow-colors = [list:
-    red, orange, yellow, green, blue, indigo, violet]
+  rainbow-colors = [list: red, orange, yellow, green, blue, indigo, violet]
 
   render-image(single-bars.default-color(red)) satisfies is-image
   render-image(single-bars.colors(single-color)) satisfies is-image

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -20,7 +20,7 @@ single-bars-neg = from-list.bar-chart(
 
 single-bars-rep = from-list.bar-chart(
   [list: "Pyret", "OCaml", "C", "C++", "Python", "Racket", "Pyret"],
-  [list: 10,       6,       1,   3,     5,       8,        9])
+  [list: 10,       6,       1,   3,     5.5,       8,        9])
 
 ######################
 # GROUPED BAR CHARTS 
@@ -168,7 +168,7 @@ fun count-vowels(s):
 end
 
 ################################################################################
-# Actual Testing -- Check
+# Actual Testing -- Checks
 ################################################################################
 
 #####################
@@ -287,6 +287,8 @@ more-colors = [list: red, green, blue, orange, purple, yellow, indigo, violet]
 
 check "Color Methods: Single Bars":
   render-image(single-bars.default-color(red)) satisfies is-image
+  render-image(single-bars-neg.default-color(green)) satisfies is-image
+  render-image(single-bars-rep.default-color(violet)) satisfies is-image
 
   render-image(single-bars.colors(empty)) satisfies is-image
   render-image(single-bars.colors(single-color)) satisfies is-image
@@ -294,6 +296,8 @@ check "Color Methods: Single Bars":
   render-image(single-bars.colors(manual-colors)) satisfies is-image
   render-image(single-bars.colors(less-colors)) satisfies is-image
   render-image(single-bars.colors(more-colors)) satisfies is-image
+  render-image(single-bars-neg.colors(rainbow-colors)) satisfies is-image
+  render-image(single-bars-rep.colors(more-colors)) satisfies is-image
 end
 
 check "Color Methods: Grouped Bars":
@@ -303,6 +307,9 @@ check "Color Methods: Grouped Bars":
   render-image(grouped-bars.colors(manual-colors)) satisfies is-image
   render-image(grouped-bars.colors(less-colors)) satisfies is-image
   render-image(grouped-bars.colors(more-colors)) satisfies is-image
+  render-image(grouped-bars-neg.colors(single-color)) satisfies is-image
+  render-image(grouped-bars-rep.colors(less-colors)) satisfies is-image
+  render-image(grouped-bars-repgroups.colors(more-colors)) satisfies is-image
 end
 
 check "Color Methods: Stacked Bars":
@@ -312,6 +319,9 @@ check "Color Methods: Stacked Bars":
   render-image(stacked-bars.colors(manual-colors)) satisfies is-image
   render-image(stacked-bars.colors(less-colors)) satisfies is-image
   render-image(stacked-bars.colors(more-colors)) satisfies is-image
+  render-image(stacked-bars-neg.colors(manual-colors)) satisfies is-image
+  render-image(stacked-bars-rep.colors(single-color)) satisfies is-image
+  render-image(stacked-bars-repstacks.colors(rainbow-colors)) satisfies is-image
 end
 
 ########################
@@ -337,44 +347,232 @@ str-len-eq = {(a, b): string-length(a) == string-length(b)}
 vowel-eq = {(a, b): count-vowels(a) == count-vowels(b)}
 
 #### Scoring Functions ####
-  sum = {(l): fold({(acc, elm): acc + elm}, 0, l)}
-  get-first = {(l): l.get(0)}
-  pos-only-sum = {(l): sum(filter({(elm): elm > 0}, l))}
-  priority-scoring = 
-    {(coeff, l): fold2({(acc, e1, e2): acc + (e1 * e2)}, 0, coeff, l)}
-  weekend-weekday-scoring = 
-    {(l): priority-scoring([list: 1, 1, 1, 1, 1, -1, -1], l)}
+sum = {(l): fold({(acc, elm): acc + elm}, 0, l)}
+get-first = {(l): l.get(0)}
+pos-only-sum = {(l): sum(filter({(elm): elm > 0}, l))}
+priority-scoring = 
+  {(coeff, l): fold2({(acc, e1, e2): acc + (e1 * e2)}, 0, coeff, l)}
+weekend-weekday-scoring = 
+  {(l): priority-scoring([list: 1, 1, 1, 1, 1, -1, -1], l)}
 
 check "Sorting Methods: Single Bars":
   render-image(single-bars.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
   render-image(single-bars.sort-by(descending-cmp, vanilla-eq)) satisfies is-image
   render-image(single-bars.sort-by(ascending-even-priority, vanilla-eq)) satisfies is-image
+  render-image(single-bars-neg.sort-by(descending-cmp, vanilla-eq)) satisfies is-image
+  render-image(single-bars-rep.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
 
   render-image(single-bars.sort-by-label(ascending-cmp, vanilla-eq)) satisfies is-image
   render-image(single-bars.sort-by-label(descending-cmp, vanilla-eq)) satisfies is-image
   render-image(single-bars.sort-by-label(descending-str-len, str-len-eq)) satisfies is-image
   render-image(single-bars.sort-by-label(ascending-vowels, vowel-eq)) satisfies is-image
+  render-image(single-bars-neg.sort-by-label(descending-str-len, str-len-eq)) satisfies is-image
+  render-image(single-bars-rep.sort-by-label(ascending-vowels, vowel-eq)) satisfies is-image
+end
+
+check "Sorting Methods: Grouped Bars":
+  render-image(grouped-bars.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(grouped-bars.sort-by(descending-cmp, vanilla-eq)) satisfies is-image
+  render-image(grouped-bars.sort-by(ascending-even-priority, vanilla-eq)) satisfies is-image
+  render-image(grouped-bars-neg.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(grouped-bars-rep.sort-by(ascending-even-priority, vanilla-eq)) satisfies is-image
+  render-image(grouped-bars-repgroups.sort-by(descending-cmp, vanilla-eq)) satisfies is-image
+
+  render-image(grouped-bars.sort-by-label(ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(grouped-bars.sort-by-label(descending-cmp, vanilla-eq)) satisfies is-image
+  render-image(grouped-bars.sort-by-label(ascending-vowels, vowel-eq)) satisfies is-image
+  render-image(grouped-bars-neg.sort-by-label(ascending-vowels, vowel-eq)) satisfies is-image
+  render-image(grouped-bars-rep.sort-by-label(descending-cmp, vanilla-eq)) satisfies is-image
+  render-image(grouped-bars-repgroups.sort-by-label(ascending-cmp, vanilla-eq)) 
+    satisfies is-image
+
+  render-image(grouped-bars.sort-by-data(sum, ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(grouped-bars.sort-by-data(sum, descending-cmp, vanilla-eq)) 
+    satisfies is-image
+  render-image(grouped-bars.sort-by-data(sum, ascending-even-priority, vanilla-eq)) 
+    satisfies is-image
+  render-image(grouped-bars.sort-by-data(get-first, descending-cmp, vanilla-eq)) 
+    satisfies is-image
+  render-image(grouped-bars-neg.sort-by-data(pos-only-sum, ascending-cmp, vanilla-eq)) 
+    satisfies is-image
+  render-image(grouped-bars-repgroups.sort-by-data(sum, ascending-even-priority, vanilla-eq)) 
+    satisfies is-image
+  render-image(
+    grouped-bars-rep.sort-by-data(weekend-weekday-scoring, ascending-cmp, vanilla-eq)) 
+    satisfies is-image
+
 end
 
 check "Sorting Methods: Stacked Bars":
   render-image(stacked-bars.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
   render-image(stacked-bars.sort-by(descending-cmp, vanilla-eq)) satisfies is-image
   render-image(stacked-bars.sort-by(ascending-even-priority, vanilla-eq)) satisfies is-image
+  render-image(stacked-bars-neg.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(stacked-bars-rep.sort-by(ascending-even-priority, vanilla-eq)) satisfies is-image
+  render-image(stacked-bars-repstacks.sort-by(descending-cmp, vanilla-eq)) satisfies is-image
 
   render-image(stacked-bars.sort-by-label(ascending-cmp, vanilla-eq)) satisfies is-image
   render-image(stacked-bars.sort-by-label(descending-cmp, vanilla-eq)) satisfies is-image
   render-image(stacked-bars.sort-by-label(ascending-vowels, vowel-eq)) satisfies is-image
+  render-image(stacked-bars-neg.sort-by-label(ascending-vowels, vowel-eq)) satisfies is-image
+  render-image(stacked-bars-rep.sort-by-label(descending-cmp, vanilla-eq)) satisfies is-image
+  render-image(stacked-bars-repstacks.sort-by-label(ascending-cmp, vanilla-eq)) 
+    satisfies is-image
 
   render-image(stacked-bars.sort-by-data(sum, ascending-cmp, vanilla-eq)) satisfies is-image
-  render-image(stacked-bars.sort-by-data(sum, descending-cmp, vanilla-eq)) 
-  satisfies is-image
+  render-image(stacked-bars.sort-by-data(sum, descending-cmp, vanilla-eq)) satisfies is-image
   render-image(stacked-bars.sort-by-data(sum, ascending-even-priority, vanilla-eq)) 
-  satisfies is-image
+    satisfies is-image
   render-image(stacked-bars.sort-by-data(get-first, descending-cmp, vanilla-eq)) 
-  satisfies is-image
+    satisfies is-image
   render-image(stacked-bars-neg.sort-by-data(pos-only-sum, ascending-cmp, vanilla-eq)) 
-  satisfies is-image
+    satisfies is-image
+  render-image(stacked-bars-repstacks.sort-by-data(sum, ascending-even-priority, vanilla-eq)) 
+    satisfies is-image
   render-image(
     stacked-bars-rep.sort-by-data(weekend-weekday-scoring, ascending-cmp, vanilla-eq)) 
-  satisfies is-image
+    satisfies is-image
+end
+
+#############################
+# ADD POINTERS METHOD TESTS 
+#############################
+
+check "Add Pointers Method: Single Bars": 
+  render-image(single-bars.add-pointers(empty, empty)) satisfies is-image
+  render-image(single-bars.add-pointers([list: 6, 7], [list: "median", "mean + 1"])) 
+    satisfies is-image
+  render-image(single-bars.add-pointers(
+    [list: -10000000, 900000000], 
+    [list: "to-far-below", "to-far-above"])) # Wont show up
+    satisfies is-image
+  render-image(single-bars.add-pointers([list: 0, 4, 10], [list: "zero", "four", "max"]))
+    satisfies is-image
+  render-image(single-bars-neg.add-pointers([list: 3, 1, -2, -5], [list: "a", "b", "c", "d"]))
+    satisfies is-image
+  render-image(single-bars-neg.add-pointers([list: 1.546, -2.213], [list: 'decimal', 'negdec']))
+    satisfies is-image
+  render-image(single-bars-rep.add-pointers([list: 3, 5], [list: 'tres', 'cinco']))
+    satisfies is-image
+
+  render-image(single-bars.add-pointers(empty, [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(single-bars.add-pointers([list: 0], empty))
+    raises "pointers values and names should have the same length"
+  render-image(single-bars.add-pointers([list: 0], [list: "base", "target"]))
+    raises "pointers values and names should have the same length"
+  render-image(single-bars.add-pointers([list: 0, 1], [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(single-bars-neg.add-pointers([list: 0], [list: "base", "target"]))
+    raises "pointers values and names should have the same length"
+  render-image(single-bars-rep.add-pointers([list: 0, 1], [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(single-bars.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(single-bars-neg.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(single-bars-rep.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+end
+
+check "Add Pointers Method: Grouped Bars": 
+  render-image(grouped-bars.add-pointers(empty, empty)) satisfies is-image
+  render-image(grouped-bars.add-pointers(
+    [list: 1874094, 41417373 / 14], 
+    [list: "median (All Bars)", "mean (All Bars)"])) 
+    satisfies is-image
+  render-image(grouped-bars.add-pointers(
+    [list: -10000000, 900000000], 
+    [list: "to-far-below", "to-far-above"])) # Wont show up
+    satisfies is-image
+  render-image(grouped-bars.add-pointers(
+    [list: 0, 6000000, 12000000], 
+    [list: "zero", "middle", "max"]))
+    satisfies is-image
+  render-image(grouped-bars-neg.add-pointers(
+    [list: 0.3, 0, -1.5, -3], 
+    [list: "a", "b", "c", "d"]))
+    satisfies is-image
+  render-image(grouped-bars-rep.add-pointers(
+    [list: 3.5, 9], 
+    [list: "Decimal", "Almost Max"]))
+    satisfies is-image
+  render-image(grouped-bars-repgroups.add-pointers(
+    [list: 6, 9], 
+    [list: "Almost Middle", "Almost Max"]))
+    satisfies is-image
+
+  render-image(grouped-bars.add-pointers(empty, [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(grouped-bars.add-pointers([list: 0], empty))
+    raises "pointers values and names should have the same length"
+  render-image(grouped-bars.add-pointers([list: 0], [list: "base", "target"]))
+    raises "pointers values and names should have the same length"
+  render-image(grouped-bars.add-pointers([list: 0, 1], [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(grouped-bars-neg.add-pointers([list: 0], [list: "base", "target"]))
+    raises "pointers values and names should have the same length"
+  render-image(grouped-bars-rep.add-pointers([list: 0, 1], [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(grouped-bars-repgroups.add-pointers(empty, [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(grouped-bars.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(grouped-bars-neg.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(grouped-bars-rep.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(grouped-bars-repgroups.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+end
+
+check "Add Pointers Method: Stacked Bars": 
+  render-image(stacked-bars.add-pointers(empty, empty)) satisfies is-image
+  render-image(stacked-bars.add-pointers(
+    [list: 18409317.5, 20708686.5],
+    [list: "median", "mean"])) 
+    satisfies is-image
+  render-image(stacked-bars.add-pointers(
+    [list: -10000000, 900000000], 
+    [list: "to-far-below", "to-far-above"])) # Wont show up
+    satisfies is-image
+  render-image(stacked-bars.add-pointers(
+    [list: 0, 20000000, 40000000], 
+    [list: "zero", "middle", "max"]))
+    satisfies is-image
+  render-image(stacked-bars-neg.add-pointers(
+    [list: 1.3, 0, -1.5, -3], 
+    [list: "a", "b", "c", "d"]))
+    satisfies is-image
+  render-image(stacked-bars-rep.add-pointers(
+    [list: 3.5, 59], 
+    [list: "Decimal", "Almost Max"]))
+    satisfies is-image
+  render-image(stacked-bars-repstacks.add-pointers(
+    [list: 31, 59], 
+    [list: "Almost Middle", "Almost Max"]))
+    satisfies is-image
+
+  render-image(stacked-bars.add-pointers(empty, [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(stacked-bars.add-pointers([list: 0], empty))
+    raises "pointers values and names should have the same length"
+  render-image(stacked-bars.add-pointers([list: 0], [list: "base", "target"]))
+    raises "pointers values and names should have the same length"
+  render-image(stacked-bars.add-pointers([list: 0, 1], [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(stacked-bars-neg.add-pointers([list: 0], [list: "base", "target"]))
+    raises "pointers values and names should have the same length"
+  render-image(stacked-bars-rep.add-pointers([list: 0, 1], [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(stacked-bars-repstacks.add-pointers(empty, [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(stacked-bars.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(stacked-bars-neg.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(stacked-bars-rep.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(stacked-bars-repstacks.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
 end

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -183,7 +183,7 @@ check "Rendering: Single Bars":
   from-list.bar-chart(empty, empty)
   raises "can't have empty data"
 
-  from-list.bar-chart([list: "label"], empty) 
+  from-list.bar-chart([list: "label1", "label2"], [list: 1]) 
   raises "labels and values should have the same length"
 
   from-list.bar-chart([list: "label"], [list: 1, 2]) 
@@ -236,7 +236,7 @@ check "Rendering: Stacked Bars":
   render-image(stacked-bars-rep) satisfies is-image
   render-image(stacked-bars-repstacks) satisfies is-image
 
-  from-list.grouped-bar-chart(empty, empty, empty)
+  from-list.stacked-bar-chart(empty, empty, empty)
   raises "can't have empty data"
 
   from-list.stacked-bar-chart(
@@ -251,7 +251,7 @@ check "Rendering: Stacked Bars":
         [list: 'Component 1', 'Component 2'])
   raises "labels and values should have the same length"
   
-  from-list.stackd-bar-chart(
+  from-list.stacked-bar-chart(
         [list: 'Bar 1', 'Bar 2'],
         [list: [list: 1, 3], [list: 2, 2], [list: 0, -3]], 
         [list: 'Component 1', 'Component 2']) 

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -61,4 +61,7 @@ check "colors":
 
   render-image(grouped-bars.colors(single-color)) satisfies is-image
   render-image(grouped-bars.colors(rainbow-colors)) satisfies is-image
+
+  render-image(stacked-bars.colors(single-color)) satisfies is-image
+  render-image(stacked-bars.colors(rainbow-colors)) satisfies is-image
 end

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -378,3 +378,8 @@ check "Sorting Methods: Stacked Bars":
     stacked-bars-rep.sort-by-data(weekend-weekday-scoring, ascending-cmp, vanilla-eq)) 
   satisfies is-image
 end
+
+########################
+# AXIS FORMATTER TESTS 
+########################
+

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -6,9 +6,25 @@ include image
 # CONSTANTS
 ################################################################################
 
+#####################
+# SINGLE BAR CHARTS 
+#####################
+
 single-bars = from-list.bar-chart(
   [list: "Pyret", "OCaml", "C", "C++", "Python", "Racket", "Smalltalk"],
   [list: 10,       6,       1,   3,     5,       8,        9])
+
+single-bars-neg = from-list.bar-chart(
+  [list: "Pyret", "OCaml", "C", "C++", "Python", "Racket", "Smalltalk"],
+  [list: -10,       -6,       1,   3,     -5,       -8,        -9])
+
+single-bars-rep = from-list.bar-chart(
+  [list: "Pyret", "OCaml", "C", "C++", "Python", "Racket", "Pyret"],
+  [list: 10,       6,       1,   3,     5,       8,        9])
+
+######################
+# GROUPED BAR CHARTS 
+######################
 
 grouped-bars = from-list.grouped-bar-chart(
   [list: 'CA', 'TX', 'NY', 'FL', 'IL', 'PA'],
@@ -28,6 +44,52 @@ grouped-bars = from-list.grouped-bar-chart(
     '45 to 64 Years',
     '65 Years and Over'])
 
+grouped-bars-neg = from-list.grouped-bar-chart(
+    [list: '2010', '2011', '2012', '2013', '2014', 
+   '2015', '2016', '2017', '2018', '2019'],
+  [list: 
+    [list: -3.78, -1.14, -1.06, -3.54, -1.74, -1.23, 0.42],
+    [list: -3.81, -1.18, -1.05, -3.56, -1.77, -1.25, 0.35],
+    [list: -3.83, -1.21, -1.04, -3.58, -1.81, -1.27, 0.27],
+    [list: -3.84, -1.24, -1.05, -3.60, -1.86, -1.29, 0.18],
+    [list: -3.86, -1.27, -1.06, -3.61, -1.91, -1.31, 0.09],
+    [list: -3.87, -1.29, -1.06, -3.63, -1.97, -1.33, 0],
+    [list: -3.88, -1.31, -1.07, -3.64, -2.03, -1.35, -0.08],
+    [list: -3.89, -1.32, -1.07, -3.66, -2.09, -1.36, -0.17],
+    [list: -3.90, -1.33, -1.07, -3.67, -2.15, -1.38, -0.25],
+    [list: -3.91, -1.34, -1.07, -3.68, -2.21, -1.39, -0.33]],
+  [list: 'Asia', 'North America', 'Europe', 
+     'South America', 'Africa', 'Oceania', 'Angola'])
+
+grouped-bars-rep = from-list.grouped-bar-chart(
+    [list: 'Liam', 'Elijah', 'Ava', 'Sophia', 'Ava', 'Emma'],
+    [list: 
+      [list: 10, 8, 10, 4, 8, 9, 7],
+    [list: 9, 7, 8, 9, 5, 5, 8], 
+      [list: 8, 10, 9, 4, 5, 10, 7],
+      [list: 10, 6, 7, 4, 10, 6, 5], 
+      [list: 8, 8, 9, 8, 4, 4, 5], 
+      [list: 6, 9, 8, 6, 9, 10, 7]], 
+    [list: 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 
+   'Friday', 'Saturday', 'Sunday'])
+
+grouped-bars-repgroups = from-list.grouped-bar-chart(
+    [list: 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 
+   'Friday', 'Saturday', 'Sunday'], 
+    [list: 
+      [list: 10, 9, 8, 10, 8, 6], 
+      [list: 8, 7, 10, 6, 8, 9],
+      [list: 10, 9, 9, 7, 9, 8], 
+    [list: 4, 9, 4, 4, 8, 6], 
+    [list: 8, 5, 5, 10, 4, 9], 
+    [list: 9, 5, 10, 6, 4, 10], 
+    [list: 7, 8, 7, 5, 5, 7]],
+    [list: 'Liam', 'Elijah', 'Ava', 'Sophia', 'Ava', 'Emma'])
+
+######################
+# STACKED BAR CHARTS 
+######################
+
 stacked-bars = from-list.stacked-bar-chart(
   [list: 'CA', 'TX', 'NY', 'FL', 'IL', 'PA'],
   [list:
@@ -46,6 +108,48 @@ stacked-bars = from-list.stacked-bar-chart(
     '45 to 64 Years',
     '65 Years and Over'])
 
+stacked-bars-neg = from-list.stacked-bar-chart(
+    [list: '2010', '2011', '2012', '2013', '2014', 
+   '2015', '2016', '2017', '2018', '2019'],
+  [list: 
+    [list: -3.78, -1.14, -1.06, -3.54, -1.74, -1.23, 0.42],
+    [list: -3.81, -1.18, -1.05, -3.56, -1.77, -1.25, 0.35],
+    [list: -3.83, -1.21, -1.04, -3.58, -1.81, -1.27, 0.27],
+    [list: -3.84, -1.24, -1.05, -3.60, -1.86, -1.29, 0.18],
+    [list: -3.86, -1.27, -1.06, -3.61, -1.91, -1.31, 0.09],
+    [list: -3.87, -1.29, -1.06, -3.63, -1.97, -1.33, 0],
+    [list: -3.88, -1.31, -1.07, -3.64, -2.03, -1.35, -0.08],
+    [list: -3.89, -1.32, -1.07, -3.66, -2.09, -1.36, -0.17],
+    [list: -3.90, -1.33, -1.07, -3.67, -2.15, -1.38, -0.25],
+    [list: -3.91, -1.34, -1.07, -3.68, -2.21, -1.39, -0.33]],
+  [list: 'Asia', 'North America', 'Europe', 
+     'South America', 'Africa', 'Oceania', 'Angola'])
+
+stacked-bars-rep = from-list.stacked-bar-chart(
+    [list: 'Liam', 'Elijah', 'Ava', 'Sophia', 'Ava', 'Emma'],
+    [list: 
+      [list: 10, 8, 10, 4, 8, 9, 7],
+    [list: 9, 7, 8, 9, 5, 5, 8], 
+      [list: 8, 10, 9, 4, 5, 10, 7],
+      [list: 10, 6, 7, 4, 10, 6, 5], 
+      [list: 8, 8, 9, 8, 4, 4, 5], 
+      [list: 6, 9, 8, 6, 9, 10, 7]], 
+    [list: 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 
+   'Friday', 'Saturday', 'Sunday'])
+
+stacked-bars-repstacks = from-list.stacked-bar-chart(
+    [list: 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 
+   'Friday', 'Saturday', 'Sunday'], 
+    [list: 
+      [list: 10, 9, 8, 10, 8, 6], 
+      [list: 8, 7, 10, 6, 8, 9],
+      [list: 10, 9, 9, 7, 9, 8], 
+    [list: 4, 9, 4, 4, 8, 6], 
+    [list: 8, 5, 5, 10, 4, 9], 
+    [list: 9, 5, 10, 6, 4, 10], 
+    [list: 7, 8, 7, 5, 5, 7]],
+    [list: 'Liam', 'Elijah', 'Ava', 'Sophia', 'Ava', 'Emma'])
+
 ################################################################################
 # Helper Functions -- Testing 
 ################################################################################
@@ -54,27 +158,223 @@ fun render-image(series):
   render-chart(series).get-image()
 end
 
+fun count-vowels(s): 
+  fold(
+    {(acc, elm): 
+      if string-explode('aeiouAEIOU').member(elm): acc + 1
+      else: acc
+      end
+    }, 0, string-explode(s))
+end
+
 ################################################################################
 # Actual Testing -- Check
 ################################################################################
 
-check "Rendering":
+#####################
+# RENDERING TESTS 
+#####################
+
+check "Rendering: Single Bars":
   render-image(single-bars) satisfies is-image
-  render-image(grouped-bars) satisfies is-image
-  render-image(stacked-bars) satisfies is-image
+  render-image(single-bars-neg) satisfies is-image
+  render-image(single-bars-rep) satisfies is-image
+
+  from-list.bar-chart(empty, empty)
+  raises "can't have empty data"
+
+  from-list.bar-chart([list: "label"], empty) 
+  raises "labels and values should have the same length"
+
+  from-list.bar-chart([list: "label"], [list: 1, 2]) 
+  raises "labels and values should have the same length"
 end
 
-check "Color Methods: Doesn't Break Rendering":
-  single-color = [list: red]
-  rainbow-colors = [list: red, orange, yellow, green, blue, indigo, violet]
+check "Rendering: Grouped Bars": 
+  render-image(grouped-bars) satisfies is-image
+  render-image(grouped-bars-neg) satisfies is-image
+  render-image(grouped-bars-rep) satisfies is-image
+  render-image(grouped-bars-repgroups) satisfies is-image
 
+  from-list.grouped-bar-chart(empty, empty, empty)
+  raises "can't have empty data"
+
+  from-list.grouped-bar-chart(
+        [list: 'There', 'are', 'no', 'stacks'],
+        [list: empty, empty, empty, empty], 
+        empty) 
+  raises "can't have empty legends"
+
+  from-list.grouped-bar-chart(
+        [list: 'Bar 1', 'Bar 2', 'Bar 3', 'Bar 4'],
+        [list: [list: 1, 3], [list: 2, 2], [list: 0, -3]], 
+        [list: 'Component 1', 'Component 2'])
+  raises "labels and values should have the same length"
+  
+  from-list.grouped-bar-chart(
+        [list: 'Bar 1', 'Bar 2'],
+        [list: [list: 1, 3], [list: 2, 2], [list: 0, -3]], 
+        [list: 'Component 1', 'Component 2']) 
+  raises "labels and values should have the same length"
+  
+  from-list.grouped-bar-chart(
+        [list: 'Bar 1', 'Bar 2', 'Bar 3', 'Bar 4'],
+        [list: [list: 1, 3], [list: 2, 2], [list: 0, -3], [list: 1, 2]], 
+        [list: 'Component 1', 'Component 2', 'Component 3'])
+  raises "labels and legends should have the same length"
+
+  from-list.grouped-bar-chart(
+        [list: 'Bar 1', 'Bar 2', 'Bar 3', 'Bar 4'],
+        [list: [list: 1, 3], [list: 2, 2], [list: 0, -3], [list: 1]], 
+        [list: 'Component 1', 'Component 2'])
+  raises "labels and legends should have the same length"
+end
+
+check "Rendering: Stacked Bars": 
+  render-image(stacked-bars) satisfies is-image
+  render-image(stacked-bars-neg) satisfies is-image
+  render-image(stacked-bars-rep) satisfies is-image
+  render-image(stacked-bars-repstacks) satisfies is-image
+
+  from-list.grouped-bar-chart(empty, empty, empty)
+  raises "can't have empty data"
+
+  from-list.stacked-bar-chart(
+        [list: 'There', 'are', 'no', 'stacks'],
+        [list: empty, empty, empty, empty], 
+        empty) 
+  raises "can't have empty legends"
+
+  from-list.stacked-bar-chart(
+        [list: 'Bar 1', 'Bar 2', 'Bar 3', 'Bar 4'],
+        [list: [list: 1, 3], [list: 2, 2], [list: 0, -3]], 
+        [list: 'Component 1', 'Component 2'])
+  raises "labels and values should have the same length"
+  
+  from-list.stackd-bar-chart(
+        [list: 'Bar 1', 'Bar 2'],
+        [list: [list: 1, 3], [list: 2, 2], [list: 0, -3]], 
+        [list: 'Component 1', 'Component 2']) 
+  raises "labels and values should have the same length"
+  
+  from-list.stacked-bar-chart(
+        [list: 'Bar 1', 'Bar 2', 'Bar 3', 'Bar 4'],
+        [list: [list: 1, 3], [list: 2, 2], [list: 0, -3], [list: 1, 2]], 
+        [list: 'Component 1', 'Component 2', 'Component 3'])
+  raises "labels and legends should have the same length"
+
+  from-list.stacked-bar-chart(
+        [list: 'Bar 1', 'Bar 2', 'Bar 3', 'Bar 4'],
+        [list: [list: 1, 3], [list: 2, 2], [list: 0, -3], [list: 1]], 
+        [list: 'Component 1', 'Component 2'])
+  raises "labels and legends should have the same length"
+end
+
+######################
+# COLOR METHOD TESTS 
+######################
+
+single-color = [list: red]
+rainbow-colors = [list: red, orange, yellow, green, blue, indigo, violet]
+manual-colors = 
+  [list: 
+    color(51, 72, 252, 0.57), color(195, 180, 104, 0.87), 
+    color(115, 23, 159, 0.24), color(144, 12, 138, 0.13), 
+    color(31, 132, 224, 0.83), color(166, 16, 72, 0.59), 
+    color(58, 193, 241, 0.98)]
+less-colors = [list: red, green, blue, orange, purple]
+more-colors = [list: red, green, blue, orange, purple, yellow, indigo, violet]
+
+check "Color Methods: Single Bars":
   render-image(single-bars.default-color(red)) satisfies is-image
+
+  render-image(single-bars.colors(empty)) satisfies is-image
   render-image(single-bars.colors(single-color)) satisfies is-image
   render-image(single-bars.colors(rainbow-colors)) satisfies is-image
+  render-image(single-bars.colors(manual-colors)) satisfies is-image
+  render-image(single-bars.colors(less-colors)) satisfies is-image
+  render-image(single-bars.colors(more-colors)) satisfies is-image
+end
 
+check "Color Methods: Grouped Bars":
+  render-image(grouped-bars.colors(empty)) satisfies is-image
   render-image(grouped-bars.colors(single-color)) satisfies is-image
   render-image(grouped-bars.colors(rainbow-colors)) satisfies is-image
+  render-image(grouped-bars.colors(manual-colors)) satisfies is-image
+  render-image(grouped-bars.colors(less-colors)) satisfies is-image
+  render-image(grouped-bars.colors(more-colors)) satisfies is-image
+end
 
+check "Color Methods: Stacked Bars":
+  render-image(stacked-bars.colors(empty)) satisfies is-image
   render-image(stacked-bars.colors(single-color)) satisfies is-image
   render-image(stacked-bars.colors(rainbow-colors)) satisfies is-image
+  render-image(stacked-bars.colors(manual-colors)) satisfies is-image
+  render-image(stacked-bars.colors(less-colors)) satisfies is-image
+  render-image(stacked-bars.colors(more-colors)) satisfies is-image
+end
+
+########################
+# SORTING METHOD TESTS 
+########################
+
+#### CMP Functions ####
+ascending-cmp = {(a, b): a < b}
+descending-cmp = {(a, b): a > b}
+descending-str-len = {(a, b): string-length(a) > string-length(b)}
+ascending-even-priority = 
+  {(a, b):
+    ask: 
+      | num-modulo(a, 2) == num-modulo(b, 2) then: a < b
+      | num-modulo(a, 2) == 0 then: true 
+      | num-modulo(b, 2) == 0 then: false
+    end}
+ascending-vowels = {(a, b): count-vowels(a) < count-vowels(b)}
+
+#### EQ Functions ####
+vanilla-eq = {(a, b): a == b}
+str-len-eq = {(a, b): string-length(a) == string-length(b)}
+vowel-eq = {(a, b): count-vowels(a) == count-vowels(b)}
+
+#### Scoring Functions ####
+  sum = {(l): fold({(acc, elm): acc + elm}, 0, l)}
+  get-first = {(l): l.get(0)}
+  pos-only-sum = {(l): sum(filter({(elm): elm > 0}, l))}
+  priority-scoring = 
+    {(coeff, l): fold2({(acc, e1, e2): acc + (e1 * e2)}, 0, coeff, l)}
+  weekend-weekday-scoring = 
+    {(l): priority-scoring([list: 1, 1, 1, 1, 1, -1, -1], l)}
+
+check "Sorting Methods: Single Bars":
+  render-image(single-bars.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(single-bars.sort-by(descending-cmp, vanilla-eq)) satisfies is-image
+  render-image(single-bars.sort-by(ascending-even-priority, vanilla-eq)) satisfies is-image
+
+  render-image(single-bars.sort-by-label(ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(single-bars.sort-by-label(descending-cmp, vanilla-eq)) satisfies is-image
+  render-image(single-bars.sort-by-label(descending-str-len, str-len-eq)) satisfies is-image
+  render-image(single-bars.sort-by-label(ascending-vowels, vowel-eq)) satisfies is-image
+end
+
+check "Sorting Methods: Stacked Bars":
+  render-image(stacked-bars.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(stacked-bars.sort-by(descending-cmp, vanilla-eq)) satisfies is-image
+  render-image(stacked-bars.sort-by(ascending-even-priority, vanilla-eq)) satisfies is-image
+
+  render-image(stacked-bars.sort-by-label(ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(stacked-bars.sort-by-label(descending-cmp, vanilla-eq)) satisfies is-image
+  render-image(stacked-bars.sort-by-label(ascending-vowels, vowel-eq)) satisfies is-image
+
+  render-image(stacked-bars.sort-by-data(sum, ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(stacked-bars.sort-by-data(sum, descending-cmp, vanilla-eq)) 
+  satisfies is-image
+  render-image(stacked-bars.sort-by-data(sum, ascending-even-priority, vanilla-eq)) 
+  satisfies is-image
+  render-image(stacked-bars.sort-by-data(get-first, descending-cmp, vanilla-eq)) 
+  satisfies is-image
+  render-image(stacked-bars-neg.sort-by-data(pos-only-sum, ascending-cmp, vanilla-eq)) 
+  satisfies is-image
+  render-image(
+    stacked-bars-rep.sort-by-data(weekend-weekday-scoring, ascending-cmp, vanilla-eq)) 
+  satisfies is-image
 end


### PR DESCRIPTION
I encountered an issue with rendering a single bar chart, so this pull request adds the `color` field to `BarChartSeries`.

To help find similar errors, this pull request also adds an extra .arr file to test-util/pyret-programs/charts which tests bar chart functionality. Most of the tests are extremely basic at the moment, as they only check to see if the charts render and don't check for correctness.

(In retrospect I should have split these up.)

Note: If the charts don't render, the test actually hangs. Hopefully this can get fixed, but I doubt it will because Pyret can't access the underlying asynchronous framework.