### PR TITLE
Sbc orientation

### DIFF
--- a/src/web/arr/trove/chart.arr
+++ b/src/web/arr/trove/chart.arr
@@ -359,7 +359,7 @@ axis-pointer-method = method(self,
   end
 
   ticks = fold2({(acc, e1, e2): link(pointer(e1, e2), acc)}, empty, tickLabels, tickValues)
-  self.constr()(self.obj.{pointers: some(ticks)})
+  self.constr()(self.obj.{pointers: some(distinct(ticks))})
 end
 
 make-axis-data-method = method(self,  pos-bar-height :: Number, neg-bar-height :: Number):
@@ -393,7 +393,9 @@ make-axis-data-method = method(self,  pos-bar-height :: Number, neg-bar-height :
   pos-ticks = map(name-tick, range-by(0, axisTop + step, step))
   neg-ticks = map(name-tick, range-by(0, axisBottom - step, -1 * step))
 
-  self.constr()(self.obj.{axisdata: some(axis-data(axisTop, axisBottom, pos-ticks + neg-ticks))})
+  self.constr()(
+    self.obj.{axisdata: some(axis-data(axisTop, axisBottom, distinct(pos-ticks + neg-ticks)))}
+    )
 end
 
 format-axis-data-method = method(self, format-func :: (Number -> String)):
@@ -542,7 +544,8 @@ type BarChartSeries = {
   color :: Option<I.Color>,
   colors :: Option<List<I.Color>>,
   pointers :: Option<List<Pointer>>, 
-  pointer-color :: Option<I.Color>
+  pointer-color :: Option<I.Color>, 
+  horizontal :: Boolean
 }
 
 default-bar-chart-series = {
@@ -550,7 +553,8 @@ default-bar-chart-series = {
   colors: none,
   pointers: none, 
   pointer-color: none,
-  axisdata: none
+  axisdata: none, 
+  horizontal: false 
 }
 
 type MultiBarChartSeries = { 
@@ -560,7 +564,8 @@ type MultiBarChartSeries = {
   is-stacked :: String,
   colors :: Option<List<I.Color>>, 
   pointers :: Option<List<Pointer>>, 
-  pointer-color :: Option<I.Color>
+  pointer-color :: Option<I.Color>, 
+  horizontal :: Boolean
 }
 
 default-multi-bar-chart-series = {
@@ -568,7 +573,8 @@ default-multi-bar-chart-series = {
   colors: some([list: C.red, C.blue, C.green, C.orange, C.purple, C.black, C.brown]),
   pointers: none, 
   pointer-color: none,
-  axisdata: none
+  axisdata: none, 
+  horizontal: false 
 }
   
 type HistogramSeries = {
@@ -759,6 +765,9 @@ data DataSeries:
     format-axis: format-axis-data-method, 
     make-axis: make-axis-data-method, 
     scale: scale-method, 
+    method horizontal(self, b :: Boolean):
+      self.constr()(self.obj.{horizontal: b})
+    end,
     constr: {(): bar-chart-series},
   | multi-bar-chart-series(obj :: MultiBarChartSeries) with: 
     is-single: true,
@@ -772,6 +781,9 @@ data DataSeries:
     make-axis: make-axis-data-method,
     scale: multi-scale-method,
     stacking-type: stacking-type-method, 
+    method horizontal(self, b :: Boolean):
+      self.constr()(self.obj.{horizontal: b})
+    end,
     constr: {(): multi-bar-chart-series}
   | box-plot-series(obj :: BoxChartSeries) with:
     is-single: true,

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -294,6 +294,7 @@
   function barChart(globalOptions, rawData) {
     // Variables and constants 
     const table = get(rawData, 'tab');
+    var horizontal = get(rawData, 'horizontal');
     const data = new google.visualization.DataTable();
     var colors_list = [];
     var default_color = "";
@@ -358,18 +359,19 @@
     var options = {
         legend: {
           position: 'none'
-        },
-        vAxes: {
-          0: {
-            viewWindow: { 
-              max: axisTop, 
-              min: axisBottom
-            }, 
-            ticks: ticks
-          }
         }
       }
 
+    var axisloc = horizontal ? 'hAxes' : 'vAxes';
+    
+
+    console.log(axisTop, axisBottom, ticks);
+    options[axisloc] =
+    { 0: { viewWindow: { max: axisTop, min: axisBottom }, 
+           ticks: ticks
+         }
+    }
+    
      /* NOTE(John & Edward, Dec 2020): 
        Our goal for the part below was to add pointers (Specific Named Ticks) on another VAxis. 
        The Current Chart library necessitates that we assign at least one stack/bar to the 
@@ -385,7 +387,7 @@
       options['series'] = { 1: { color: pointer_color, targetAxisIndex: 1 } };
 
       // Update Options to include the new axis ticks consistent with the first axis
-      options['vAxes'][1] = { 
+      options[axisloc][1] = { 
         viewWindow: { 
           max: axisTop, 
           min: axisBottom
@@ -399,7 +401,7 @@
     return {
       data: data,
       options: options,
-      chartType: google.visualization.ColumnChart,
+      chartType: horizontal ? google.visualization.BarChart : google.visualization.ColumnChart,
       onExit: defaultImageReturn,
       mutators: [axesNameMutator, yAxisRangeMutator],
     };
@@ -409,6 +411,7 @@
     // Variables and Constants
     const table = get(rawData, 'tab');
     const legends = get(rawData, 'legends');
+    var horizontal = get(rawData, 'horizontal');
     const data = new google.visualization.DataTable();
     var colors_list = [];
     var pointers_list = [];
@@ -460,20 +463,17 @@
         isStacked: get(rawData, 'is-stacked'),
         series: colors_list.map(c => ({color: c, targetAxisIndex: 0})),
         legend: {
-          position: 'top', 
+          position: horizontal ? 'right' : 'top', 
           maxLines: data.If.length - 1
         }
       }
 
-    var customAxesNeeded = (get(rawData, 'is-stacked') === 'none') || (get(rawData, 'is-stacked') === 'absolute')
-    
-    options['vAxes'] = //customAxesNeeded ? 
+    var axisloc = horizontal ? 'hAxes' : 'vAxes';
+    options[axisloc] =
     { 0: { viewWindow: { max: axisTop, min: axisBottom }, 
            ticks: ticks }
-    } //: { 0: null }
+    }
          
-  
-
     /* NOTE(John & Edward, Dec 2020): 
        Our goal for the part below was to add pointers (Specific Named Ticks) on another VAxis. 
        The Current Chart library necessitates that we assign at least one stack/bar to the 
@@ -490,7 +490,7 @@
       options['series'][(data.If.length - 2)] = {color: pointer_color, targetAxisIndex: 1};
 
       // Update Options to include the new axis ticks consistent with the first axis
-      options['vAxes'][1] = { 
+      options[axisloc][1] = { 
         viewWindow: { 
           max: axisTop, 
           min: axisBottom
@@ -504,7 +504,7 @@
     return {
       data: data,
       options: options,
-      chartType: google.visualization.ColumnChart,
+      chartType: horizontal ? google.visualization.BarChart : google.visualization.ColumnChart,
       onExit: defaultImageReturn,
       mutators: [axesNameMutator, yAxisRangeMutator],
     };

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -338,8 +338,8 @@
       cases(RUNTIME.ffi.isOption, 'Option', get(rawData, 'axisdata'), {
           none: function () {},
           some: function (axisdata) {
-            axisTop = axisdata.dict.axisTop;
-            axisBottom = axisdata.dict.axisBottom;
+            axisTop = toFixnum(axisdata.dict.axisTop);
+            axisBottom = toFixnum(axisdata.dict.axisBottom);
             ticks = convertListWith(convertPointer, axisdata.dict.ticks);
           }
       });
@@ -435,8 +435,8 @@
     cases(RUNTIME.ffi.isOption, 'Option', get(rawData, 'axisdata'), {
           none: function () {},
           some: function (axisdata) {
-            axisTop = axisdata.dict.axisTop;
-            axisBottom = axisdata.dict.axisBottom;
+            axisTop = toFixnum(axisdata.dict.axisTop);
+            axisBottom = toFixnum(axisdata.dict.axisBottom);
             ticks = convertListWith(convertPointer, axisdata.dict.ticks);
           }
     });

--- a/src/web/js/trove/chart-lib.js
+++ b/src/web/js/trove/chart-lib.js
@@ -462,17 +462,17 @@
         legend: {
           position: 'top', 
           maxLines: data.If.length - 1
-        },
-        vAxes: {
-          0: {
-            viewWindow: { 
-              max: axisTop, 
-              min: axisBottom
-            }, 
-            ticks: ticks
-          }
         }
       }
+
+    var customAxesNeeded = (get(rawData, 'is-stacked') === 'none') || (get(rawData, 'is-stacked') === 'absolute')
+    
+    options['vAxes'] = //customAxesNeeded ? 
+    { 0: { viewWindow: { max: axisTop, min: axisBottom }, 
+           ticks: ticks }
+    } //: { 0: null }
+         
+  
 
     /* NOTE(John & Edward, Dec 2020): 
        Our goal for the part below was to add pointers (Specific Named Ticks) on another VAxis. 

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -448,11 +448,26 @@ check "Add Pointers Method: Single Bars":
     satisfies is-image
   render-image(single-bars.add-pointers([list: 0, 4, 10], [list: "zero", "four", "max"]))
     satisfies is-image
+  render-image(single-bars.add-pointers([list: 4], [list: "thislabelnameiswaytoolong"]))
+    satisfies is-image
   render-image(single-bars-neg.add-pointers([list: 3, 1, -2, -5], [list: "a", "b", "c", "d"]))
     satisfies is-image
   render-image(single-bars-neg.add-pointers([list: 1.546, -2.213], [list: 'decimal', 'negdec']))
     satisfies is-image
   render-image(single-bars-rep.add-pointers([list: 3, 5], [list: 'tres', 'cinco']))
+    satisfies is-image
+
+  render-image(
+    single-bars.add-pointers([list: 6, 7], [list: "median", "mean + 1"])
+               .pointer-color(red)) 
+    satisfies is-image
+  render-image(
+    single-bars-neg.add-pointers([list: 3, 1, -2, -5], [list: "a", "b", "c", "d"])
+                   .pointer-color(green)) 
+    satisfies is-image
+  render-image(
+    single-bars-rep.add-pointers([list: 3, 5], [list: 'tres', 'cinco'])
+                   .pointer-color(cyan)) 
     satisfies is-image
 
   render-image(single-bars.add-pointers(empty, [list: "base"]))
@@ -489,6 +504,10 @@ check "Add Pointers Method: Grouped Bars":
     [list: 0, 6000000, 12000000], 
     [list: "zero", "middle", "max"]))
     satisfies is-image
+  render-image(grouped-bars.add-pointers(
+    [list: 6000000], 
+    [list: "thislabelnameiswaytoolong"]))
+    satisfies is-image
   render-image(grouped-bars-neg.add-pointers(
     [list: 0.3, 0, -1.5, -3], 
     [list: "a", "b", "c", "d"]))
@@ -500,6 +519,25 @@ check "Add Pointers Method: Grouped Bars":
   render-image(grouped-bars-repgroups.add-pointers(
     [list: 6, 9], 
     [list: "Almost Middle", "Almost Max"]))
+    satisfies is-image
+
+  render-image(
+    grouped-bars.add-pointers([list: 1874094, 41417373 / 14], 
+                              [list: "median (All Bars)", "mean (All Bars)"])
+               .pointer-color(red)) 
+    satisfies is-image
+  render-image(
+    grouped-bars-neg.add-pointers([list: 0.3, 0, -1.5, -3], 
+                                  [list: "a", "b", "c", "d"])
+                   .pointer-color(magenta)) 
+    satisfies is-image
+  render-image(
+    grouped-bars-rep.add-pointers([list: 3.5, 9], [list: "Decimal", "Almost Max"])
+                   .pointer-color(yellow)) 
+    satisfies is-image
+  render-image(
+    grouped-bars-repgroups.add-pointers([list: 6, 9], [list: "~Mid", "~Max"])
+                          .pointer-color(orange)) 
     satisfies is-image
 
   render-image(grouped-bars.add-pointers(empty, [list: "base"]))
@@ -540,6 +578,10 @@ check "Add Pointers Method: Stacked Bars":
     [list: 0, 20000000, 40000000], 
     [list: "zero", "middle", "max"]))
     satisfies is-image
+  render-image(stacked-bars.add-pointers(
+    [list: 20000000], 
+    [list: "thislabelnameiswaytoolong"]))
+    satisfies is-image
   render-image(stacked-bars-neg.add-pointers(
     [list: 1.3, 0, -1.5, -3], 
     [list: "a", "b", "c", "d"]))
@@ -551,6 +593,23 @@ check "Add Pointers Method: Stacked Bars":
   render-image(stacked-bars-repstacks.add-pointers(
     [list: 31, 59], 
     [list: "Almost Middle", "Almost Max"]))
+    satisfies is-image
+
+  render-image(
+    stacked-bars.add-pointers([list: 18409317.5, 20708686.5], [list: "median", "mean"])
+                .pointer-color(red)) 
+    satisfies is-image
+  render-image(
+    stacked-bars-neg.add-pointers([list: 1.3, 0, -1.5, -3], [list: "a", "b", "c", "d"])
+                    .pointer-color(magenta)) 
+    satisfies is-image
+  render-image(
+    stacked-bars-rep.add-pointers([list: 3.5, 59], [list: "Decimal", "Almost Max"])
+                    .pointer-color(yellow)) 
+    satisfies is-image
+  render-image(
+    stacked-bars-repstacks.add-pointers([list: 31, 59], [list: "Almost Middle", "Almost Max"])
+                          .pointer-color(orange)) 
     satisfies is-image
 
   render-image(stacked-bars.add-pointers(empty, [list: "base"]))
@@ -575,4 +634,57 @@ check "Add Pointers Method: Stacked Bars":
     raises "pointers cannot overlap"
   render-image(stacked-bars-repstacks.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
     raises "pointers cannot overlap"
+end
+
+################################
+# AXIS FORMATTING METHOD TESTS 
+################################
+
+check "Axis Formatting Methods: Single Bars":
+  render-image(single-bars.format-axis({(n): num-to-string(n)})) satisfies is-image
+  render-image(single-bars.format-axis({(n): num-to-string(n) + " votes"})) satisfies is-image
+  render-image(single-bars.format-axis({(n): "Counted " + num-to-string(n) + " votes"}))
+    satisfies is-image
+  render-image(single-bars.format-axis({(n): num-to-string(n / 10) + " * 10"})) 
+    satisfies is-image
+  render-image(single-bars.format-axis({(_): "?"})) 
+    satisfies is-image
+  render-image(single-bars-neg.format-axis({(n): num-to-string(n / 10) + " * 10"}) 
+    satisfies is-image
+  render-image(single-bars-rep.format-axis({(n): num-to-string(n) + " votes"})) 
+    satisfies is-image
+end
+
+check "Axis Formatting Methods: Grouped Bars":
+  render-image(grouped-bars.format-axis({(n): num-to-string(n)})) satisfies is-image
+  render-image(grouped-bars.format-axis({(n): num-to-string(n) + " people"})) satisfies is-image
+  render-image(grouped-bars.format-axis({(n): "For " + num-to-string(n) + " people"}))
+    satisfies is-image
+  render-image(grouped-bars.format-axis({(n): num-to-string(n / 10) + " * 10"})) 
+    satisfies is-image
+  render-image(grouped-bars.format-axis({(_): "?"})) 
+    satisfies is-image
+  render-image(grouped-bars-neg.format-axis({(n): num-to-string-digits(n, 2) + " Δ Fertility Rate"})) 
+    satisfies is-image
+  render-image(grouped-bars-rep.format-axis({(n): num-to-string(n) + " hours"})) 
+    satisfies is-image
+  render-image(grouped-bars-repgroups.format-axis({(n):"For " + num-to-string(n) + " hours"})) 
+    satisfies is-image
+end
+
+check "Axis Formatting Methods: Stacked Bars":
+  render-image(stacked-bars.format-axis({(n): num-to-string(n)})) satisfies is-image
+  render-image(stacked-bars.format-axis({(n): num-to-string(n) + " people"})) satisfies is-image
+  render-image(stacked-bars.format-axis({(n): "For " + num-to-string(n) + " people"}))
+    satisfies is-image
+  render-image(stacked-bars.format-axis({(n): num-to-string(n / 10) + " * 10"})) 
+    satisfies is-image
+  render-image(stacked-bars.format-axis({(_): "?"})) 
+    satisfies is-image
+  render-image(stacked-bars-neg.format-axis({(n): num-to-string-digits(n, 2) + " Δ Fertility Rate"})) 
+    satisfies is-image
+  render-image(stacked-bars-rep.format-axis({(n): num-to-string(n) + " hours"})) 
+    satisfies is-image
+  render-image(stacked-bars-repstacks.format-axis({(n):"For " + num-to-string(n) + " hours"})) 
+    satisfies is-image
 end

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -688,3 +688,44 @@ check "Axis Formatting Methods: Stacked Bars":
   render-image(stacked-bars-repstacks.format-axis({(n):"For " + num-to-string(n) + " hours"})) 
     satisfies is-image
 end
+
+######################
+# SCALE METHOD TESTS 
+######################
+
+check "Scale Methods: Single Bars":
+  render-image(single-bars.scale({(n): n})) satisfies is-image
+  render-image(single-bars.scale({(n): n + 5})) satisfies is-image
+  render-image(single-bars.scale({(n): 2 * n})) satisfies is-image
+  render-image(single-bars.scale({(n): n / 100})) satisfies is-image
+  render-image(single-bars.scale(num-log)) satisfies is-image
+  render-image(single-bars.scale({(n): (2 * n) + 231}).scale(num-log)) satisfies is-image
+  render-image(single-bars-neg.scale({(n): (2 * n) + 231})) satisfies is-image
+  render-image(single-bars-rep.scale({(n): n * n})) satisfies is-image
+end
+
+check "Scale Methods: Grouped Bars":
+  render-image(grouped-bars.scale({(n): n})) satisfies is-image
+  render-image(grouped-bars.scale({(n): n + 5})) satisfies is-image
+  render-image(grouped-bars.scale({(n): 2 * n})) satisfies is-image
+  render-image(grouped-bars.scale({(n): n / 100})) satisfies is-image
+  render-image(grouped-bars.scale(num-log)) satisfies is-image
+  render-image(grouped-bars.scale({(n): (2 * n) + 231}).scale(num-log)) satisfies is-image
+  render-image(grouped-bars-neg.scale({(n): (2 * n) + 231})) satisfies is-image
+  render-image(grouped-bars-rep.scale({(n): n * n})) satisfies is-image
+  render-image(grouped-bars-repgroups.scale({(n): n / 100})) satisfies is-image
+end
+
+check "Scale Methods: Stacked Bars":
+  render-image(stacked-bars.scale({(n): n})) satisfies is-image
+  render-image(stacked-bars.scale({(n): n + 5})) satisfies is-image
+  render-image(stacked-bars.scale({(n): 2 * n})) satisfies is-image
+  render-image(stacked-bars.scale({(n): n / 100})) satisfies is-image
+  render-image(stacked-bars.scale(num-log)) satisfies is-image
+  render-image(stacked-bars.scale({(n): (2 * n) + 231}).scale(num-log)) satisfies is-image
+  render-image(stacked-bars-neg.scale({(n): (2 * n) + 231})) satisfies is-image
+  render-image(stacked-bars-rep.scale({(n): n * n})) satisfies is-image
+  render-image(stacked-bars-repstacks.scale({(n): n / 100})) satisfies is-image
+end
+
+

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -22,6 +22,14 @@ single-bars-rep = from-list.bar-chart(
   [list: "Pyret", "OCaml", "C", "C++", "Python", "Racket", "Pyret"],
   [list: 10,       6,       1,   3,     5.5,       8,        9])
 
+single-bars-roughall = from-list.bar-chart(
+  [list: "Pyret", "OCaml", "C", "C++", "Python", "Racket", "Smalltalk"],
+  [list: ~10.1141,   ~6,   ~20,   ~-3.23,     ~0,       ~8,        ~92.2])
+
+single-bars-roughsome = from-list.bar-chart(
+  [list: "Pyret", "OCaml", "C", "C++", "Python", "Racket", "Smalltalk"],
+  [list: 10.1141,   ~6,   20,   -3.23,     ~0,       ~8,        ~92.2])
+
 ######################
 # GROUPED BAR CHARTS 
 ######################
@@ -46,7 +54,7 @@ grouped-bars = from-list.grouped-bar-chart(
 
 grouped-bars-neg = from-list.grouped-bar-chart(
     [list: '2010', '2011', '2012', '2013', '2014', 
-   '2015', '2016', '2017', '2018', '2019'],
+           '2015', '2016', '2017', '2018', '2019'],
   [list: 
     [list: -3.78, -1.14, -1.06, -3.54, -1.74, -1.23, 0.42],
     [list: -3.81, -1.18, -1.05, -3.56, -1.77, -1.25, 0.35],
@@ -65,7 +73,7 @@ grouped-bars-rep = from-list.grouped-bar-chart(
     [list: 'Liam', 'Elijah', 'Ava', 'Sophia', 'Ava', 'Emma'],
     [list: 
       [list: 10, 8, 10, 4, 8, 9, 7],
-    [list: 9, 7, 8, 9, 5, 5, 8], 
+      [list: 9, 7, 8, 9, 5, 5, 8], 
       [list: 8, 10, 9, 4, 5, 10, 7],
       [list: 10, 6, 7, 4, 10, 6, 5], 
       [list: 8, 8, 9, 8, 4, 4, 5], 
@@ -75,16 +83,52 @@ grouped-bars-rep = from-list.grouped-bar-chart(
 
 grouped-bars-repgroups = from-list.grouped-bar-chart(
     [list: 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 
-   'Friday', 'Saturday', 'Sunday'], 
+           'Friday', 'Saturday', 'Sunday'], 
     [list: 
       [list: 10, 9, 8, 10, 8, 6], 
       [list: 8, 7, 10, 6, 8, 9],
       [list: 10, 9, 9, 7, 9, 8], 
-    [list: 4, 9, 4, 4, 8, 6], 
-    [list: 8, 5, 5, 10, 4, 9], 
-    [list: 9, 5, 10, 6, 4, 10], 
-    [list: 7, 8, 7, 5, 5, 7]],
+      [list: 4, 9, 4, 4, 8, 6], 
+      [list: 8, 5, 5, 10, 4, 9], 
+      [list: 9, 5, 10, 6, 4, 10], 
+      [list: 7, 8, 7, 5, 5, 7]],
     [list: 'Liam', 'Elijah', 'Ava', 'Sophia', 'Ava', 'Emma'])
+
+grouped-bars-roughall = from-list.grouped-bar-chart(
+    [list: 'Sticky Sam', 'Sticky Sam: Even Stickier', 
+           'Adhesive Adrian DLC', 'Sticky Sam on Mobile', 
+           'Sticky Sam 3: The Return'], 
+    [list: 
+      [list: ~5, ~8, ~5, ~8, ~1, ~2], 
+      [list: ~8, ~3, ~4, ~10, ~0, ~3],
+      [list: ~8, ~1, ~10, ~3, ~1, ~8], 
+      [list: ~7, ~2, ~5, ~7, ~3, ~4], 
+      [list: ~4, ~8, ~5, ~3, ~1, ~7]],
+    [list: 
+      'People actively involved in the Community', 
+      'People who want specific new features', 
+      'People who are making mods', 
+      'People who have played the game over 100 hours',
+      'People who have returned the game', 
+      'People who preordered the game']) 
+
+grouped-bars-roughsome = from-list.grouped-bar-chart(
+    [list: 'Sticky Sam', 'Sticky Sam: Even Stickier', 
+           'Adhesive Adrian DLC', 'Sticky Sam on Mobile', 
+           'Sticky Sam 3: The Return'], 
+    [list: 
+      [list: 5, ~8, 5, 8, ~1, 2], 
+      [list: ~8, ~3, 4, ~10, ~0, ~3],
+      [list: 8, ~1, ~10, ~3, 1, 8], 
+      [list: ~7, ~2, ~5, ~7, ~3, ~4], 
+      [list: ~4, ~8, 5, ~3, ~1, ~7]],
+    [list: 
+      'People actively involved in the Community', 
+      'People who want specific new features', 
+      'People who are making mods', 
+      'People who have played the game over 100 hours',
+      'People who have returned the game', 
+      'People who preordered the game']) 
 
 ######################
 # STACKED BAR CHARTS 
@@ -110,45 +154,81 @@ stacked-bars = from-list.stacked-bar-chart(
 
 stacked-bars-neg = from-list.stacked-bar-chart(
     [list: '2010', '2011', '2012', '2013', '2014', 
-   '2015', '2016', '2017', '2018', '2019'],
-  [list: 
-    [list: -3.78, -1.14, -1.06, -3.54, -1.74, -1.23, 0.42],
-    [list: -3.81, -1.18, -1.05, -3.56, -1.77, -1.25, 0.35],
-    [list: -3.83, -1.21, -1.04, -3.58, -1.81, -1.27, 0.27],
-    [list: -3.84, -1.24, -1.05, -3.60, -1.86, -1.29, 0.18],
-    [list: -3.86, -1.27, -1.06, -3.61, -1.91, -1.31, 0.09],
-    [list: -3.87, -1.29, -1.06, -3.63, -1.97, -1.33, 0],
-    [list: -3.88, -1.31, -1.07, -3.64, -2.03, -1.35, -0.08],
-    [list: -3.89, -1.32, -1.07, -3.66, -2.09, -1.36, -0.17],
-    [list: -3.90, -1.33, -1.07, -3.67, -2.15, -1.38, -0.25],
-    [list: -3.91, -1.34, -1.07, -3.68, -2.21, -1.39, -0.33]],
-  [list: 'Asia', 'North America', 'Europe', 
-     'South America', 'Africa', 'Oceania', 'Angola'])
+           '2015', '2016', '2017', '2018', '2019'],
+    [list: 
+      [list: -3.78, -1.14, -1.06, -3.54, -1.74, -1.23, 0.42],
+      [list: -3.81, -1.18, -1.05, -3.56, -1.77, -1.25, 0.35],
+      [list: -3.83, -1.21, -1.04, -3.58, -1.81, -1.27, 0.27],
+      [list: -3.84, -1.24, -1.05, -3.60, -1.86, -1.29, 0.18],
+      [list: -3.86, -1.27, -1.06, -3.61, -1.91, -1.31, 0.09],
+      [list: -3.87, -1.29, -1.06, -3.63, -1.97, -1.33, 0],
+      [list: -3.88, -1.31, -1.07, -3.64, -2.03, -1.35, -0.08],
+      [list: -3.89, -1.32, -1.07, -3.66, -2.09, -1.36, -0.17],
+      [list: -3.90, -1.33, -1.07, -3.67, -2.15, -1.38, -0.25],
+      [list: -3.91, -1.34, -1.07, -3.68, -2.21, -1.39, -0.33]],
+    [list: 'Asia', 'North America', 'Europe', 
+           'South America', 'Africa', 'Oceania', 'Angola'])
 
 stacked-bars-rep = from-list.stacked-bar-chart(
     [list: 'Liam', 'Elijah', 'Ava', 'Sophia', 'Ava', 'Emma'],
     [list: 
       [list: 10, 8, 10, 4, 8, 9, 7],
-    [list: 9, 7, 8, 9, 5, 5, 8], 
+      [list: 9, 7, 8, 9, 5, 5, 8], 
       [list: 8, 10, 9, 4, 5, 10, 7],
       [list: 10, 6, 7, 4, 10, 6, 5], 
       [list: 8, 8, 9, 8, 4, 4, 5], 
       [list: 6, 9, 8, 6, 9, 10, 7]], 
     [list: 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 
-   'Friday', 'Saturday', 'Sunday'])
+           'Friday', 'Saturday', 'Sunday'])
 
 stacked-bars-repstacks = from-list.stacked-bar-chart(
     [list: 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 
-   'Friday', 'Saturday', 'Sunday'], 
+           'Friday', 'Saturday', 'Sunday'], 
     [list: 
       [list: 10, 9, 8, 10, 8, 6], 
       [list: 8, 7, 10, 6, 8, 9],
       [list: 10, 9, 9, 7, 9, 8], 
-    [list: 4, 9, 4, 4, 8, 6], 
-    [list: 8, 5, 5, 10, 4, 9], 
-    [list: 9, 5, 10, 6, 4, 10], 
-    [list: 7, 8, 7, 5, 5, 7]],
+      [list: 4, 9, 4, 4, 8, 6], 
+      [list: 8, 5, 5, 10, 4, 9], 
+      [list: 9, 5, 10, 6, 4, 10], 
+      [list: 7, 8, 7, 5, 5, 7]],
     [list: 'Liam', 'Elijah', 'Ava', 'Sophia', 'Ava', 'Emma'])
+
+stacked-bars-roughall = from-list.stacked-bar-chart(
+    [list: 'Sticky Sam', 'Sticky Sam: Even Stickier', 
+           'Adhesive Adrian DLC', 'Sticky Sam on Mobile', 
+           'Sticky Sam 3: The Return'], 
+    [list: 
+      [list: ~5, ~8, ~5, ~8, ~1, ~2], 
+      [list: ~8, ~3, ~4, ~10, ~0, ~3],
+      [list: ~8, ~1, ~10, ~3, ~1, ~8], 
+      [list: ~7, ~2, ~5, ~7, ~3, ~4], 
+      [list: ~4, ~8, ~5, ~3, ~1, ~7]],
+    [list: 
+      'People actively involved in the Community', 
+      'People who want specific new features', 
+      'People who are making mods', 
+      'People who have played the game over 100 hours',
+      'People who have returned the game', 
+      'People who preordered the game']) 
+
+stacked-bars-roughsome = from-list.stacked-bar-chart(
+    [list: 'Sticky Sam', 'Sticky Sam: Even Stickier', 
+           'Adhesive Adrian DLC', 'Sticky Sam on Mobile', 
+           'Sticky Sam 3: The Return'], 
+    [list: 
+      [list: 5, ~8, 5, 8, ~1, 2], 
+      [list: ~8, ~3, 4, ~10, ~0, ~3],
+      [list: 8, ~1, ~10, ~3, 1, 8], 
+      [list: ~7, ~2, ~5, ~7, ~3, ~4], 
+      [list: ~4, ~8, 5, ~3, ~1, ~7]],
+    [list: 
+      'People actively involved in the Community', 
+      'People who want specific new features', 
+      'People who are making mods', 
+      'People who have played the game over 100 hours',
+      'People who have returned the game', 
+      'People who preordered the game'])
 
 ################################################################################
 # Helper Functions -- Testing 
@@ -179,6 +259,8 @@ check "Rendering: Single Bars":
   render-image(single-bars) satisfies is-image
   render-image(single-bars-neg) satisfies is-image
   render-image(single-bars-rep) satisfies is-image
+  render-image(single-bars-roughall) satisfies is-image
+  render-image(single-bars-roughsome) satisfies is-image
 
   from-list.bar-chart(empty, empty)
   raises "can't have empty data"
@@ -195,6 +277,8 @@ check "Rendering: Grouped Bars":
   render-image(grouped-bars-neg) satisfies is-image
   render-image(grouped-bars-rep) satisfies is-image
   render-image(grouped-bars-repgroups) satisfies is-image
+  render-image(grouped-bars-roughall) satisfies is-image
+  render-image(grouped-bars-roughsome) satisfies is-image
 
   from-list.grouped-bar-chart(empty, empty, empty)
   raises "can't have empty data"
@@ -235,6 +319,8 @@ check "Rendering: Stacked Bars":
   render-image(stacked-bars-neg) satisfies is-image
   render-image(stacked-bars-rep) satisfies is-image
   render-image(stacked-bars-repstacks) satisfies is-image
+  render-image(stacked-bars-roughall) satisfies is-image
+  render-image(stacked-bars-roughsome) satisfies is-image
 
   from-list.stacked-bar-chart(empty, empty, empty)
   raises "can't have empty data"
@@ -289,6 +375,8 @@ check "Color Methods: Single Bars":
   render-image(single-bars.default-color(red)) satisfies is-image
   render-image(single-bars-neg.default-color(green)) satisfies is-image
   render-image(single-bars-rep.default-color(violet)) satisfies is-image
+  render-image(single-bars-roughall.default-color(orange)) satisfies is-image
+  render-image(single-bars-roughsome.default-color(cyan)) satisfies is-image
 
   render-image(single-bars.colors(empty)) satisfies is-image
   render-image(single-bars.colors(single-color)) satisfies is-image
@@ -298,6 +386,8 @@ check "Color Methods: Single Bars":
   render-image(single-bars.colors(more-colors)) satisfies is-image
   render-image(single-bars-neg.colors(rainbow-colors)) satisfies is-image
   render-image(single-bars-rep.colors(more-colors)) satisfies is-image
+  render-image(single-bars-roughall.colors(manual-colors)) satisfies is-image
+  render-image(single-bars-roughsome.colors(less-colors)) satisfies is-image
 end
 
 check "Color Methods: Grouped Bars":
@@ -310,6 +400,8 @@ check "Color Methods: Grouped Bars":
   render-image(grouped-bars-neg.colors(single-color)) satisfies is-image
   render-image(grouped-bars-rep.colors(less-colors)) satisfies is-image
   render-image(grouped-bars-repgroups.colors(more-colors)) satisfies is-image
+  render-image(grouped-bars-roughall.colors(manual-colors)) satisfies is-image
+  render-image(grouped-bars-roughsome.colors(rainbow-colors)) satisfies is-image
 end
 
 check "Color Methods: Stacked Bars":
@@ -322,6 +414,8 @@ check "Color Methods: Stacked Bars":
   render-image(stacked-bars-neg.colors(manual-colors)) satisfies is-image
   render-image(stacked-bars-rep.colors(single-color)) satisfies is-image
   render-image(stacked-bars-repstacks.colors(rainbow-colors)) satisfies is-image
+  render-image(stacked-bars-roughall.colors(more-colors)) satisfies is-image
+  render-image(stacked-bars-roughsome.colors(less-colors)) satisfies is-image
 end
 
 ########################
@@ -361,6 +455,9 @@ check "Sorting Methods: Single Bars":
   render-image(single-bars.sort-by(ascending-even-priority, vanilla-eq)) satisfies is-image
   render-image(single-bars-neg.sort-by(descending-cmp, vanilla-eq)) satisfies is-image
   render-image(single-bars-rep.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(single-bars-roughall.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(single-bars-roughsome.sort-by(ascending-even-priority, vanilla-eq)) 
+    satisfies is-image
 
   render-image(single-bars.sort-by-label(ascending-cmp, vanilla-eq)) satisfies is-image
   render-image(single-bars.sort-by-label(descending-cmp, vanilla-eq)) satisfies is-image
@@ -368,6 +465,10 @@ check "Sorting Methods: Single Bars":
   render-image(single-bars.sort-by-label(ascending-vowels, vowel-eq)) satisfies is-image
   render-image(single-bars-neg.sort-by-label(descending-str-len, str-len-eq)) satisfies is-image
   render-image(single-bars-rep.sort-by-label(ascending-vowels, vowel-eq)) satisfies is-image
+  render-image(single-bars-roughall.sort-by-label(descending-cmp, vanilla-eq)) 
+    satisfies is-image
+  render-image(single-bars-roughsome.sort-by-label(ascending-vowels, vowel-eq)) 
+    satisfies is-image
 end
 
 check "Sorting Methods: Grouped Bars":
@@ -377,6 +478,9 @@ check "Sorting Methods: Grouped Bars":
   render-image(grouped-bars-neg.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
   render-image(grouped-bars-rep.sort-by(ascending-even-priority, vanilla-eq)) satisfies is-image
   render-image(grouped-bars-repgroups.sort-by(descending-cmp, vanilla-eq)) satisfies is-image
+  render-image(grouped-bars-roughall.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(grouped-bars-roughsome.sort-by(ascending-even-priority, vanilla-eq)) 
+    satisfies is-image
 
   render-image(grouped-bars.sort-by-label(ascending-cmp, vanilla-eq)) satisfies is-image
   render-image(grouped-bars.sort-by-label(descending-cmp, vanilla-eq)) satisfies is-image
@@ -384,6 +488,10 @@ check "Sorting Methods: Grouped Bars":
   render-image(grouped-bars-neg.sort-by-label(ascending-vowels, vowel-eq)) satisfies is-image
   render-image(grouped-bars-rep.sort-by-label(descending-cmp, vanilla-eq)) satisfies is-image
   render-image(grouped-bars-repgroups.sort-by-label(ascending-cmp, vanilla-eq)) 
+    satisfies is-image
+  render-image(grouped-bars-roughall.sort-by-label(descending-cmp, vanilla-eq)) 
+    satisfies is-image
+  render-image(grouped-bars-roughsome.sort-by-label(ascending-vowels, vowel-eq)) 
     satisfies is-image
 
   render-image(grouped-bars.sort-by-data(sum, ascending-cmp, vanilla-eq)) satisfies is-image
@@ -400,7 +508,10 @@ check "Sorting Methods: Grouped Bars":
   render-image(
     grouped-bars-rep.sort-by-data(weekend-weekday-scoring, ascending-cmp, vanilla-eq)) 
     satisfies is-image
-
+  render-image(grouped-bars-roughall.sort-by-data(get-first, descending-cmp, vanilla-eq)) 
+    satisfies is-image
+  render-image(grouped-bars-roughsome.sort-by-data(get-first, ascending-cmp, vanilla-eq)) 
+    satisfies is-image
 end
 
 check "Sorting Methods: Stacked Bars":
@@ -410,6 +521,9 @@ check "Sorting Methods: Stacked Bars":
   render-image(stacked-bars-neg.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
   render-image(stacked-bars-rep.sort-by(ascending-even-priority, vanilla-eq)) satisfies is-image
   render-image(stacked-bars-repstacks.sort-by(descending-cmp, vanilla-eq)) satisfies is-image
+  render-image(stacked-bars-roughall.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
+  render-image(stacked-bars-roughsome.sort-by(ascending-even-priority, vanilla-eq)) 
+    satisfies is-image
 
   render-image(stacked-bars.sort-by-label(ascending-cmp, vanilla-eq)) satisfies is-image
   render-image(stacked-bars.sort-by-label(descending-cmp, vanilla-eq)) satisfies is-image
@@ -417,6 +531,10 @@ check "Sorting Methods: Stacked Bars":
   render-image(stacked-bars-neg.sort-by-label(ascending-vowels, vowel-eq)) satisfies is-image
   render-image(stacked-bars-rep.sort-by-label(descending-cmp, vanilla-eq)) satisfies is-image
   render-image(stacked-bars-repstacks.sort-by-label(ascending-cmp, vanilla-eq)) 
+    satisfies is-image
+  render-image(stacked-bars-roughall.sort-by-label(descending-cmp, vanilla-eq)) 
+    satisfies is-image
+  render-image(stacked-bars-roughsome.sort-by-label(ascending-vowels, vowel-eq)) 
     satisfies is-image
 
   render-image(stacked-bars.sort-by-data(sum, ascending-cmp, vanilla-eq)) satisfies is-image
@@ -431,6 +549,10 @@ check "Sorting Methods: Stacked Bars":
     satisfies is-image
   render-image(
     stacked-bars-rep.sort-by-data(weekend-weekday-scoring, ascending-cmp, vanilla-eq)) 
+    satisfies is-image
+  render-image(stacked-bars-roughall.sort-by-data(get-first, descending-cmp, vanilla-eq)) 
+    satisfies is-image
+  render-image(stacked-bars-roughsome.sort-by-data(get-first, ascending-cmp, vanilla-eq)) 
     satisfies is-image
 end
 
@@ -456,6 +578,10 @@ check "Pointer Method: Single Bars":
     satisfies is-image
   render-image(single-bars-rep.add-pointers([list: 3, 5], [list: 'tres', 'cinco']))
     satisfies is-image
+  render-image(single-bars-roughall.add-pointers([list: 11, 1, -5], [list: "a", "c", "d"]))
+    satisfies is-image
+  render-image(single-bars-roughsome.add-pointers([list: 40, 5], [list: 'cuarenta', 'cinco']))
+    satisfies is-image
 
   render-image(
     single-bars.add-pointers([list: 6, 7], [list: "median", "mean + 1"])
@@ -468,6 +594,14 @@ check "Pointer Method: Single Bars":
   render-image(
     single-bars-rep.add-pointers([list: 3, 5], [list: 'tres', 'cinco'])
                    .pointer-color(cyan)) 
+    satisfies is-image
+  render-image(
+    single-bars-roughall.add-pointers([list: 11, 1, -5], [list: "a", "c", "d"])
+                        .pointer-color(magenta))
+    satisfies is-image
+  render-image(
+    single-bars-roughsome.add-pointers([list: 40, 5], [list: 'cuarenta', 'cinco'])
+                         .pointer-color(orange))
     satisfies is-image
 
   render-image(single-bars.add-pointers(empty, [list: "base"]))
@@ -482,11 +616,20 @@ check "Pointer Method: Single Bars":
     raises "pointers values and names should have the same length"
   render-image(single-bars-rep.add-pointers([list: 0, 1], [list: "base"]))
     raises "pointers values and names should have the same length"
+  render-image(single-bars-roughall.add-pointers(empty, [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(single-bars-roughsome.add-pointers([list: 0], empty))
+    raises "pointers values and names should have the same length"
+
   render-image(single-bars.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
     raises "pointers cannot overlap"
   render-image(single-bars-neg.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
     raises "pointers cannot overlap"
   render-image(single-bars-rep.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(single-bars-roughall.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(single-bars-roughsome.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
     raises "pointers cannot overlap"
 end
 
@@ -520,6 +663,10 @@ check "Pointer Methods: Grouped Bars":
     [list: 6, 9], 
     [list: "Almost Middle", "Almost Max"]))
     satisfies is-image
+  render-image(grouped-bars-roughall.add-pointers([list: 8, 1, 4], [list: "a", "c", "d"]))
+    satisfies is-image
+  render-image(grouped-bars-roughsome.add-pointers([list: 3, 5], [list: 'tres', 'cinco']))
+    satisfies is-image
 
   render-image(
     grouped-bars.add-pointers([list: 1874094, 41417373 / 14], 
@@ -539,6 +686,14 @@ check "Pointer Methods: Grouped Bars":
     grouped-bars-repgroups.add-pointers([list: 6, 9], [list: "~Mid", "~Max"])
                           .pointer-color(orange)) 
     satisfies is-image
+  render-image(
+    grouped-bars-roughall.add-pointers([list: 11, 1, -5], [list: "a", "c", "d"])
+                        .pointer-color(red))
+    satisfies is-image
+  render-image(
+    grouped-bars-roughsome.add-pointers([list: 3, 5], [list: 'tres', 'cinco'])
+                         .pointer-color(cyan))
+    satisfies is-image
 
   render-image(grouped-bars.add-pointers(empty, [list: "base"]))
     raises "pointers values and names should have the same length"
@@ -554,6 +709,11 @@ check "Pointer Methods: Grouped Bars":
     raises "pointers values and names should have the same length"
   render-image(grouped-bars-repgroups.add-pointers(empty, [list: "base"]))
     raises "pointers values and names should have the same length"
+  render-image(grouped-bars-roughall.add-pointers(empty, [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(grouped-bars-roughsome.add-pointers([list: 0], empty))
+    raises "pointers values and names should have the same length"
+
   render-image(grouped-bars.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
     raises "pointers cannot overlap"
   render-image(grouped-bars-neg.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
@@ -561,6 +721,10 @@ check "Pointer Methods: Grouped Bars":
   render-image(grouped-bars-rep.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
     raises "pointers cannot overlap"
   render-image(grouped-bars-repgroups.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(grouped-bars-roughall.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(grouped-bars-roughsome.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
     raises "pointers cannot overlap"
 end
 
@@ -594,6 +758,10 @@ check "Pointers Methods: Stacked Bars":
     [list: 31, 59], 
     [list: "Almost Middle", "Almost Max"]))
     satisfies is-image
+  render-image(stacked-bars-roughall.add-pointers([list: 8, 1, 4], [list: "a", "c", "d"]))
+    satisfies is-image
+  render-image(stacked-bars-roughsome.add-pointers([list: 3, 5], [list: 'tres', 'cinco']))
+    satisfies is-image
 
   render-image(
     stacked-bars.add-pointers([list: 18409317.5, 20708686.5], [list: "median", "mean"])
@@ -611,6 +779,14 @@ check "Pointers Methods: Stacked Bars":
     stacked-bars-repstacks.add-pointers([list: 31, 59], [list: "Almost Middle", "Almost Max"])
                           .pointer-color(orange)) 
     satisfies is-image
+  render-image(
+    stacked-bars-roughall.add-pointers([list: 11, 1, -5], [list: "a", "c", "d"])
+                        .pointer-color(red))
+    satisfies is-image
+  render-image(
+    stacked-bars-roughsome.add-pointers([list: 3, 5], [list: 'tres', 'cinco'])
+                         .pointer-color(cyan))
+    satisfies is-image
 
   render-image(stacked-bars.add-pointers(empty, [list: "base"]))
     raises "pointers values and names should have the same length"
@@ -626,6 +802,11 @@ check "Pointers Methods: Stacked Bars":
     raises "pointers values and names should have the same length"
   render-image(stacked-bars-repstacks.add-pointers(empty, [list: "base"]))
     raises "pointers values and names should have the same length"
+  render-image(stacked-bars-roughall.add-pointers(empty, [list: "base"]))
+    raises "pointers values and names should have the same length"
+  render-image(stacked-bars-roughsome.add-pointers([list: 0], empty))
+    raises "pointers values and names should have the same length"
+
   render-image(stacked-bars.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
     raises "pointers cannot overlap"
   render-image(stacked-bars-neg.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
@@ -633,6 +814,10 @@ check "Pointers Methods: Stacked Bars":
   render-image(stacked-bars-rep.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
     raises "pointers cannot overlap"
   render-image(stacked-bars-repstacks.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(stacked-bars-roughall.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
+    raises "pointers cannot overlap"
+  render-image(stacked-bars-roughsome.add-pointers([list: 0, 0], [list: "dup", "duplicate"]))
     raises "pointers cannot overlap"
 end
 
@@ -653,6 +838,10 @@ check "Axis Formatting Methods: Single Bars":
     satisfies is-image
   render-image(single-bars-rep.format-axis({(n): num-to-string(n) + " votes"})) 
     satisfies is-image
+  render-image(single-bars-roughall.format-axis({(n): num-to-string(n / 10) + " * 10"})) 
+    satisfies is-image
+  render-image(single-bars-roughsome.format-axis({(n): num-to-string(n / 10) + " * 10"})) 
+    satisfies is-image
 end
 
 check "Axis Formatting Methods: Grouped Bars":
@@ -669,6 +858,10 @@ check "Axis Formatting Methods: Grouped Bars":
   render-image(grouped-bars-rep.format-axis({(n): num-to-string(n) + " hours"})) 
     satisfies is-image
   render-image(grouped-bars-repgroups.format-axis({(n):"For " + num-to-string(n) + " hours"})) 
+    satisfies is-image
+  render-image(grouped-bars-roughall.format-axis({(n): num-to-string(n / 2) + " * 2"})) 
+    satisfies is-image
+  render-image(grouped-bars-roughsome.format-axis({(n): num-to-string(n / 2) + " * 2"})) 
     satisfies is-image
 end
 
@@ -687,6 +880,10 @@ check "Axis Formatting Methods: Stacked Bars":
     satisfies is-image
   render-image(stacked-bars-repstacks.format-axis({(n):"For " + num-to-string(n) + " hours"})) 
     satisfies is-image
+  render-image(stacked-bars-roughall.format-axis({(n): num-to-string(n / 5) + " * 5"})) 
+    satisfies is-image
+  render-image(stacked-bars-roughsome.format-axis({(n): num-to-string(n / 5) + " * 5"})) 
+    satisfies is-image
 end
 
 ######################
@@ -699,9 +896,11 @@ check "Scale Methods: Single Bars":
   render-image(single-bars.scale({(n): 2 * n})) satisfies is-image
   render-image(single-bars.scale({(n): n / 100})) satisfies is-image
   render-image(single-bars.scale(num-log)) satisfies is-image
-  render-image(single-bars.scale({(n): (2 * n) + 231}).scale(num-log)) satisfies is-image
+  render-image(single-bars.scale({(n): num-expt(n, n)}).scale(num-log)) satisfies is-image
   render-image(single-bars-neg.scale({(n): (2 * n) + 231})) satisfies is-image
   render-image(single-bars-rep.scale({(n): n * n})) satisfies is-image
+  render-image(single-bars-roughall.scale({(n): n * n})) satisfies is-image
+  render-image(single-bars-roughsome.scale({(n): 2 * n})) satisfies is-image
 end
 
 check "Scale Methods: Grouped Bars":
@@ -710,10 +909,12 @@ check "Scale Methods: Grouped Bars":
   render-image(grouped-bars.scale({(n): 2 * n})) satisfies is-image
   render-image(grouped-bars.scale({(n): n / 100})) satisfies is-image
   render-image(grouped-bars.scale(num-log)) satisfies is-image
-  render-image(grouped-bars.scale({(n): (2 * n) + 231}).scale(num-log)) satisfies is-image
+  render-image(grouped-bars.scale({(n): num-expt(n, 1.5)}).scale(num-log)) satisfies is-image
   render-image(grouped-bars-neg.scale({(n): (2 * n) + 231})) satisfies is-image
-  render-image(grouped-bars-rep.scale({(n): n * n})) satisfies is-image
-  render-image(grouped-bars-repgroups.scale({(n): n / 100})) satisfies is-image
+  render-image(grouped-bars-rep.scale({(n): n * 1.5})) satisfies is-image
+  render-image(grouped-bars-repgroups.scale({(n): num-expt(n, 1.5)})) satisfies is-image
+  render-image(grouped-bars-roughall.scale({(n): n * n})) satisfies is-image
+  render-image(grouped-bars-roughsome.scale({(n): 2 * n})) satisfies is-image
 end
 
 check "Scale Methods: Stacked Bars":
@@ -722,10 +923,12 @@ check "Scale Methods: Stacked Bars":
   render-image(stacked-bars.scale({(n): 2 * n})) satisfies is-image
   render-image(stacked-bars.scale({(n): n / 100})) satisfies is-image
   render-image(stacked-bars.scale(num-log)) satisfies is-image
-  render-image(stacked-bars.scale({(n): (2 * n) + 231}).scale(num-log)) satisfies is-image
+  render-image(stacked-bars.scale({(n): (2 * n) + 231}).scale(n / 2)) satisfies is-image
   render-image(stacked-bars-neg.scale({(n): (2 * n) + 231})) satisfies is-image
   render-image(stacked-bars-rep.scale({(n): n * n})) satisfies is-image
   render-image(stacked-bars-repstacks.scale({(n): n / 100})) satisfies is-image
+  render-image(stacked-bars-roughall.scale({(n): n * n})) satisfies is-image
+  render-image(stacked-bars-roughsome.scale({(n): 2 * n})) satisfies is-image
 end
 
 

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -1002,3 +1002,50 @@ check "Stacking type: stacked Bars":
   render-image(stacked-bars-roughsome.stacking-type('')) 
     raises "stacking-type: type must be absolute, relative, percent, or none"
 end
+
+###########################
+# HORIZONTAL METHOD TESTS 
+###########################
+
+check "Horizontal Method: Single Bars":
+  render-image(single-bars.horizontal(false)) satisfies is-image
+  render-image(single-bars-neg.horizontal(false)) satisfies is-image
+  render-image(single-bars-rep.horizontal(false)) satisfies is-image
+  render-image(single-bars-roughall.horizontal(false)) satisfies is-image
+  render-image(single-bars-roughsome.horizontal(false)) satisfies is-image
+  render-image(single-bars.horizontal(true)) satisfies is-image
+  render-image(single-bars-neg.horizontal(true)) satisfies is-image
+  render-image(single-bars-rep.horizontal(true)) satisfies is-image
+  render-image(single-bars-roughall.horizontal(true)) satisfies is-image
+  render-image(single-bars-roughsome.horizontal(true)) satisfies is-image
+end
+
+check "Rendering: Grouped Bars": 
+  render-image(grouped-bars.horizontal(false)) satisfies is-image
+  render-image(grouped-bars-neg.horizontal(false)) satisfies is-image
+  render-image(grouped-bars-rep.horizontal(false)) satisfies is-image
+  render-image(grouped-bars-repgroups.horizontal(false)) satisfies is-image
+  render-image(grouped-bars-roughall.horizontal(false)) satisfies is-image
+  render-image(grouped-bars-roughsome.horizontal(false)) satisfies is-image
+  render-image(grouped-bars.horizontal(true)) satisfies is-image
+  render-image(grouped-bars-neg.horizontal(true)) satisfies is-image
+  render-image(grouped-bars-rep.horizontal(true)) satisfies is-image
+  render-image(grouped-bars-repgroups.horizontal(true)) satisfies is-image
+  render-image(grouped-bars-roughall.horizontal(true)) satisfies is-image
+  render-image(grouped-bars-roughsome.horizontal(true)) satisfies is-image
+end
+
+check "Rendering: Stacked Bars": 
+  render-image(stacked-bars.horizontal(false)) satisfies is-image
+  render-image(stacked-bars-neg.horizontal(false)) satisfies is-image
+  render-image(stacked-bars-rep.horizontal(false)) satisfies is-image
+  render-image(stacked-bars-repstacks.horizontal(false)) satisfies is-image
+  render-image(stacked-bars-roughall.horizontal(false)) satisfies is-image
+  render-image(stacked-bars-roughsome.horizontal(false)) satisfies is-image
+  render-image(stacked-bars.horizontal(true)) satisfies is-image
+  render-image(stacked-bars-neg.horizontal(true)) satisfies is-image
+  render-image(stacked-bars-rep.horizontal(true)) satisfies is-image
+  render-image(stacked-bars-repstacks.horizontal(true)) satisfies is-image
+  render-image(stacked-bars-roughall.horizontal(true)) satisfies is-image
+  render-image(stacked-bars-roughsome.horizontal(true)) satisfies is-image
+end

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -456,7 +456,7 @@ check "Sorting Methods: Single Bars":
   render-image(single-bars-neg.sort-by(descending-cmp, vanilla-eq)) satisfies is-image
   render-image(single-bars-rep.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
   render-image(single-bars-roughall.sort-by(ascending-cmp, vanilla-eq)) satisfies is-image
-  render-image(single-bars-roughsome.sort-by(ascending-even-priority, vanilla-eq)) 
+  render-image(single-bars-roughsome.sort-by(ascending-cmp, vanilla-eq)) 
     satisfies is-image
 
   render-image(single-bars.sort-by-label(ascending-cmp, vanilla-eq)) satisfies is-image
@@ -923,7 +923,7 @@ check "Scale Methods: Stacked Bars":
   render-image(stacked-bars.scale({(n): 2 * n})) satisfies is-image
   render-image(stacked-bars.scale({(n): n / 100})) satisfies is-image
   render-image(stacked-bars.scale(num-log)) satisfies is-image
-  render-image(stacked-bars.scale({(n): (2 * n) + 231}).scale(n / 2)) satisfies is-image
+  render-image(stacked-bars.scale({(n): (2 * n) + 231}).scale({(n): n / 2})) satisfies is-image
   render-image(stacked-bars-neg.scale({(n): (2 * n) + 231})) satisfies is-image
   render-image(stacked-bars-rep.scale({(n): n * n})) satisfies is-image
   render-image(stacked-bars-repstacks.scale({(n): n / 100})) satisfies is-image
@@ -931,4 +931,74 @@ check "Scale Methods: Stacked Bars":
   render-image(stacked-bars-roughsome.scale({(n): 2 * n})) satisfies is-image
 end
 
+##############################
+# STACKING TYPE METHOD TESTS 
+##############################
 
+check "Stacking type: Grouped Bars":
+  # Keep as grouped bars 
+  render-image(grouped-bars.stacking-type('none')) satisfies is-image
+  render-image(grouped-bars-neg.stacking-type('none')) satisfies is-image
+  render-image(grouped-bars-rep.stacking-type('none')) satisfies is-image
+  render-image(grouped-bars-repgroups.stacking-type('none')) satisfies is-image
+  render-image(grouped-bars-roughall.stacking-type('none')) satisfies is-image
+  render-image(grouped-bars-roughsome.stacking-type('none')) satisfies is-image
+
+  # Switch to stacked bars 
+  render-image(grouped-bars.stacking-type('absolute')) satisfies is-image
+  render-image(grouped-bars.stacking-type('relative')) satisfies is-image
+  render-image(grouped-bars.stacking-type('percent')) satisfies is-image
+  render-image(grouped-bars-neg.stacking-type('relative')) satisfies is-image
+  render-image(grouped-bars-rep.stacking-type('percent')) satisfies is-image
+  render-image(grouped-bars-repgroups.stacking-type('relative')) satisfies is-image
+  render-image(grouped-bars-roughall.stacking-type('absolute')) satisfies is-image
+  render-image(grouped-bars-roughsome.stacking-type('percent')) satisfies is-image
+
+  # Raise Errors 
+  render-image(grouped-bars.stacking-type('true')) 
+    raises "stacking-type: type must be absolute, relative, percent, or none"
+  render-image(grouped-bars-neg.stacking-type('false')) 
+    raises "stacking-type: type must be absolute, relative, percent, or none"
+  render-image(grouped-bars-rep.stacking-type('Relative')) 
+    raises "stacking-type: type must be absolute, relative, percent, or none"
+  render-image(grouped-bars-repgroups.stacking-type('Absolute')) 
+    raises "stacking-type: type must be absolute, relative, percent, or none"
+  render-image(grouped-bars-roughall.stacking-type('AFHQIEHFQOH')) 
+    raises "stacking-type: type must be absolute, relative, percent, or none"
+  render-image(grouped-bars-roughsome.stacking-type('')) 
+    raises "stacking-type: type must be absolute, relative, percent, or none"
+end
+
+check "Stacking type: stacked Bars":
+  # Switch to grouped bars 
+  render-image(stacked-bars.stacking-type('none')) satisfies is-image
+  render-image(stacked-bars-neg.stacking-type('none')) satisfies is-image
+  render-image(stacked-bars-rep.stacking-type('none')) satisfies is-image
+  render-image(stacked-bars-repstacks.stacking-type('none')) satisfies is-image
+  render-image(stacked-bars-roughall.stacking-type('none')) satisfies is-image
+  render-image(stacked-bars-roughsome.stacking-type('none')) satisfies is-image
+
+  # Switch between stacked bar types 
+  render-image(stacked-bars.stacking-type('absolute')) satisfies is-image
+  render-image(stacked-bars.stacking-type('relative')) satisfies is-image
+  render-image(stacked-bars.stacking-type('percent')) satisfies is-image
+  render-image(stacked-bars-neg.stacking-type('relative')) satisfies is-image
+  render-image(stacked-bars-rep.stacking-type('percent')) satisfies is-image
+  render-image(stacked-bars-repstacks.stacking-type('relative')) satisfies is-image
+  render-image(stacked-bars-roughall.stacking-type('absolute')) satisfies is-image
+  render-image(stacked-bars-roughsome.stacking-type('percent')) satisfies is-image
+
+  # Raise Errors 
+  render-image(stacked-bars.stacking-type('true')) 
+    raises "stacking-type: type must be absolute, relative, percent, or none"
+  render-image(stacked-bars-neg.stacking-type('false')) 
+    raises "stacking-type: type must be absolute, relative, percent, or none"
+  render-image(stacked-bars-rep.stacking-type('Relative')) 
+    raises "stacking-type: type must be absolute, relative, percent, or none"
+  render-image(stacked-bars-repstacks.stacking-type('Absolute')) 
+    raises "stacking-type: type must be absolute, relative, percent, or none"
+  render-image(stacked-bars-roughall.stacking-type('AFHQIEHFQOH')) 
+    raises "stacking-type: type must be absolute, relative, percent, or none"
+  render-image(stacked-bars-roughsome.stacking-type('')) 
+    raises "stacking-type: type must be absolute, relative, percent, or none"
+end

--- a/test-util/pyret-programs/charts/bar-chart-test.arr
+++ b/test-util/pyret-programs/charts/bar-chart-test.arr
@@ -434,11 +434,11 @@ check "Sorting Methods: Stacked Bars":
     satisfies is-image
 end
 
-#############################
-# ADD POINTERS METHOD TESTS 
-#############################
+#########################
+# POINTER METHODS TESTS 
+#########################
 
-check "Add Pointers Method: Single Bars": 
+check "Pointer Method: Single Bars": 
   render-image(single-bars.add-pointers(empty, empty)) satisfies is-image
   render-image(single-bars.add-pointers([list: 6, 7], [list: "median", "mean + 1"])) 
     satisfies is-image
@@ -490,7 +490,7 @@ check "Add Pointers Method: Single Bars":
     raises "pointers cannot overlap"
 end
 
-check "Add Pointers Method: Grouped Bars": 
+check "Pointer Methods: Grouped Bars": 
   render-image(grouped-bars.add-pointers(empty, empty)) satisfies is-image
   render-image(grouped-bars.add-pointers(
     [list: 1874094, 41417373 / 14], 
@@ -564,7 +564,7 @@ check "Add Pointers Method: Grouped Bars":
     raises "pointers cannot overlap"
 end
 
-check "Add Pointers Method: Stacked Bars": 
+check "Pointers Methods: Stacked Bars": 
   render-image(stacked-bars.add-pointers(empty, empty)) satisfies is-image
   render-image(stacked-bars.add-pointers(
     [list: 18409317.5, 20708686.5],
@@ -649,7 +649,7 @@ check "Axis Formatting Methods: Single Bars":
     satisfies is-image
   render-image(single-bars.format-axis({(_): "?"})) 
     satisfies is-image
-  render-image(single-bars-neg.format-axis({(n): num-to-string(n / 10) + " * 10"}) 
+  render-image(single-bars-neg.format-axis({(n): num-to-string(n / 10) + " * 10"})) 
     satisfies is-image
   render-image(single-bars-rep.format-axis({(n): num-to-string(n) + " votes"})) 
     satisfies is-image


### PR DESCRIPTION
Implements all the rest of the methods outlined in our documents [Except error-bars, intervals, and annotations]. Specifically axis-format, pointer methods, scaling methods, stacking type, and horizontal. 

Also added support for rough-num graphs and fleshed out the test cases. There is a CI error and I'm not sure what's causing it but all the stacked-bar-chart-tests seem to be passing. Also, After we finish combining all the code we should probably remove some of the less critical tests so as not to slow down the build speed for others. 

I think after we merge this and the error-bar, intervals, and annotations code we should have something mergeable with the actual library and we can call it for now [Adding Clustered-stacked-bar-charts later if we want, when we have the time].